### PR TITLE
attribute for transient tables

### DIFF
--- a/snowddl/parser/table.py
+++ b/snowddl/parser/table.py
@@ -108,7 +108,8 @@ table_json_schema = {
                 "additionalProperties": False
             },
             "minItems": 1
-        }
+        },
+        "is_transient": {"type": "boolean"}
     },
     "additionalProperties": False
 }


### PR DESCRIPTION
allows to specify if table is transient in table schema, so this line does not always cause a replace of the table
https://github.com/littleK0i/SnowDDL/blob/master/snowddl/resolver/table.py#L190