### PR TITLE
Allow SSO with credential caching

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,13 +32,15 @@ install_requires =
     pydantic~=2.4
     pyyaml~=6.0
     snowflake-connector-python~=3.0
-    snowflake-connector-python[secure-local-storage]~=3.0
 
 [options.extras_require]
 dev =
     black
     pytest
     ruff
+
+sso-caching =
+    snowflake-connector-python[secure-local-storage]~=3.0
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     pydantic~=2.4
     pyyaml~=6.0
     snowflake-connector-python~=3.0
+    snowflake-connector-python[secure-local-storage]~=3.0
 
 [options.extras_require]
 dev =

--- a/snowddl/app/base.py
+++ b/snowddl/app/base.py
@@ -226,7 +226,7 @@ class BaseApp:
     def init_arguments(self):
         args = vars(self.arg_parser.parse_args())
 
-        if not args["a"] or not args["u"] or (not args["p"] and not args["k"]):
+        if not args["a"] or not args["u"]:
             self.arg_parser.print_help()
             exit(1)
 
@@ -404,8 +404,10 @@ class BaseApp:
                 format=serialization.PrivateFormat.PKCS8,
                 encryption_algorithm=serialization.NoEncryption(),
             )
-        else:
+        elif self.args.get("p"):
             options["password"] = self.args["p"]
+        else:
+            options["authenticator"] = "externalbrowser"
 
         if self.args.get("query_tag"):
             options["session_parameters"] = {

--- a/snowddl/app/base.py
+++ b/snowddl/app/base.py
@@ -238,15 +238,14 @@ class BaseApp:
         return args
 
     def validate_auth_args(self, args):
-        match(args["authenticator"]):
-            case "snowflake":
-                if not args["a"] or not args["u"] or (not args["p"] and not args["k"]):
-                    return False
-            case "externalbrowser":
-                if not args["a"] or not args["u"]:
-                    return False
-            case _:
+        if args["authenticator"] == "snowflake":
+            if not args["a"] or not args["u"] or (not args["p"] and not args["k"]):
                 return False
+        elif args["authenticator"] == "externalbrowser":
+            if not args["a"] or not args["u"]:
+                return False
+        elif args["authenticator"] is not None:
+            return False
         return True
 
     def init_logger(self):
@@ -408,27 +407,26 @@ class BaseApp:
             "application": f"{self.application_name} {self.application_version}",
         }
 
-        match self.args.get("authenticator"):
-            case "snowflake":
-                if self.args.get("k"):
-                    from cryptography.hazmat.primitives import serialization
+        if self.args.get("authenticator") == "snowflake":
+            if self.args.get("k"):
+                from cryptography.hazmat.primitives import serialization
 
-                    key_path = Path(self.args.get("k"))
-                    key_password = str(self.args.get("passphrase")).encode("utf-8") if self.args.get("passphrase") else None
+                key_path = Path(self.args.get("k"))
+                key_password = str(self.args.get("passphrase")).encode("utf-8") if self.args.get("passphrase") else None
 
-                    pk = serialization.load_pem_private_key(data=key_path.read_bytes(), password=key_password)
+                pk = serialization.load_pem_private_key(data=key_path.read_bytes(), password=key_password)
 
-                    options["private_key"] = pk.private_bytes(
-                        encoding=serialization.Encoding.DER,
-                        format=serialization.PrivateFormat.PKCS8,
-                        encryption_algorithm=serialization.NoEncryption(),
-                    )
-                else:
-                    options["password"] = self.args["p"]
-            case "externalbrowser":
-                options["authenticator"] = "externalbrowser"
-            case _:
-                raise ValueError("Only 'Snowflake' and 'externalbrowser' authenticators are supported")
+                options["private_key"] = pk.private_bytes(
+                    encoding=serialization.Encoding.DER,
+                    format=serialization.PrivateFormat.PKCS8,
+                    encryption_algorithm=serialization.NoEncryption(),
+                )
+            else:
+                options["password"] = self.args["p"]
+        elif self.args.get("authenticator") == "externalbrowser":
+            options["authenticator"] = "externalbrowser"
+        else:
+            raise ValueError("Only 'Snowflake' and 'externalbrowser' authenticators are supported")
 
         if self.args.get("query_tag"):
             options["session_parameters"] = {

--- a/snowddl/app/base.py
+++ b/snowddl/app/base.py
@@ -74,6 +74,11 @@ class BaseApp:
             metavar="PRIVATE_KEY",
             default=environ.get("SNOWFLAKE_PRIVATE_KEY_PATH"),
         )
+        parser.add_argument(
+            "--authenticator",
+            help="Authenticator: 'snowflake' or 'externalbrowser' (to use any IdP and a web browser) (default: SNOWFLAKE_AUTHENTICATOR env variable or 'snowflake')",
+            default=environ.get("SNOWFLAKE_AUTHENTICATOR") or 'snowflake'
+        )
 
         # Role & warehouse
         parser.add_argument(
@@ -226,11 +231,23 @@ class BaseApp:
     def init_arguments(self):
         args = vars(self.arg_parser.parse_args())
 
-        if not args["a"] or not args["u"]:
+        if not self.validate_auth_args(args):
             self.arg_parser.print_help()
             exit(1)
 
         return args
+
+    def validate_auth_args(self, args):
+        match(args["authenticator"]):
+            case "snowflake":
+                if not args["a"] or not args["u"] or (not args["p"] and not args["k"]):
+                    return False
+            case "externalbrowser":
+                if not args["a"] or not args["u"]:
+                    return False
+            case _:
+                return False
+        return True
 
     def init_logger(self):
         logger = getLogger("snowddl")
@@ -391,23 +408,27 @@ class BaseApp:
             "application": f"{self.application_name} {self.application_version}",
         }
 
-        if self.args.get("k"):
-            from cryptography.hazmat.primitives import serialization
+        match self.args.get("authenticator"):
+            case "snowflake":
+                if self.args.get("k"):
+                    from cryptography.hazmat.primitives import serialization
 
-            key_path = Path(self.args.get("k"))
-            key_password = str(self.args.get("passphrase")).encode("utf-8") if self.args.get("passphrase") else None
+                    key_path = Path(self.args.get("k"))
+                    key_password = str(self.args.get("passphrase")).encode("utf-8") if self.args.get("passphrase") else None
 
-            pk = serialization.load_pem_private_key(data=key_path.read_bytes(), password=key_password)
+                    pk = serialization.load_pem_private_key(data=key_path.read_bytes(), password=key_password)
 
-            options["private_key"] = pk.private_bytes(
-                encoding=serialization.Encoding.DER,
-                format=serialization.PrivateFormat.PKCS8,
-                encryption_algorithm=serialization.NoEncryption(),
-            )
-        elif self.args.get("p"):
-            options["password"] = self.args["p"]
-        else:
-            options["authenticator"] = "externalbrowser"
+                    options["private_key"] = pk.private_bytes(
+                        encoding=serialization.Encoding.DER,
+                        format=serialization.PrivateFormat.PKCS8,
+                        encryption_algorithm=serialization.NoEncryption(),
+                    )
+                else:
+                    options["password"] = self.args["p"]
+            case "externalbrowser":
+                options["authenticator"] = "externalbrowser"
+            case _:
+                raise ValueError("Only 'Snowflake' and 'externalbrowser' authenticators are supported")
 
         if self.args.get("query_tag"):
             options["session_parameters"] = {


### PR DESCRIPTION
Based on the discussion here: https://github.com/littleK0i/SnowDDL/discussions/77
It is fairly straightforward to allow SSO, by passing "authenticator": "externalbrowser" to the connection option.

SSO is assumed when a user but no password is provided to the CLI.

The additional dependency is required to maintain the local credential cache, to avoid having to re-auth every time a command is issued. More details about this here: [Snowflake docs: minimize the number of prompts for authentication](https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#using-connection-caching-to-minimize-the-number-of-prompts-for-authentication-optional).

In order to use against a given Snowflake `ACCOUNT`, it is necessary to set the account-level parameter [ALLOW_ID_TOKEN](https://docs.snowflake.com/en/sql-reference/parameters.html#label-allow-id-token) to true:
```
alter account set allow_id_token = true;
```
See the documentation linked above.