### PR TITLE
Add support for optional schema role generation

### DIFF
--- a/.github/workflows/getting_started.yml
+++ b/.github/workflows/getting_started.yml
@@ -1,11 +1,11 @@
 name: Getting Started
 
 on:
-  push:
-    paths:
-      - "**.py"
-      - "**.yml"
-      - "**.yaml"
+  # push:
+  #   paths:
+  #     - "**.py"
+  #     - "**.yml"
+  #     - "**.yaml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,11 +1,11 @@
 name: Pytest
 
 on:
-  push:
-    paths:
-      - "**.py"
-      - "**.yml"
-      - "**.yaml"
+  # push:
+  #   paths:
+  #     - "**.py"
+  #     - "**.yml"
+  #     - "**.yaml"
   workflow_dispatch:
 
 jobs:

--- a/snowddl/blueprint/blueprint.py
+++ b/snowddl/blueprint/blueprint.py
@@ -252,6 +252,7 @@ class SchemaBlueprint(AbstractBlueprint):
     retention_time: Optional[int] = None
     is_sandbox: Optional[bool] = None
     owner_additional_grants: List[Grant] = []
+    schema_roles: Union[List[str], bool] = []
 
 
 class SchemaRoleBlueprint(RoleBlueprint, DependsOnMixin):

--- a/snowddl/parser/schema.py
+++ b/snowddl/parser/schema.py
@@ -16,6 +16,19 @@ schema_json_schema = {
         "is_sandbox": {
             "type": "boolean"
         },
+        "schema_roles": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "type": "boolean"
+                }
+            ],
+        },
         "owner_schema_read": {
             "type": "array",
             "items": {
@@ -84,6 +97,7 @@ class SchemaParser(AbstractParser):
                     retention_time=combined_params.get("retention_time", None),
                     is_sandbox=combined_params.get("is_sandbox", False),
                     owner_additional_grants=owner_additional_grants,
+                    schema_roles=schema_params.get("schema_roles", []),
                     comment=schema_params.get("comment", None),
                 )
 

--- a/snowddl/resolver/schema_role.py
+++ b/snowddl/resolver/schema_role.py
@@ -17,9 +17,24 @@ class SchemaRoleResolver(AbstractRoleResolver):
         blueprints = []
 
         for schema in self.config.get_blueprints_by_type(SchemaBlueprint).values():
-            blueprints.append(self.get_blueprint_owner_role(schema))
-            blueprints.append(self.get_blueprint_read_role(schema))
-            blueprints.append(self.get_blueprint_write_role(schema))
+            if schema.schema_roles == False:
+                # don't generate any roles for this schema
+                continue
+            
+            # if schema_roles attribute is not specified, create all roles by default
+            if schema.schema_roles == []:
+                blueprints.append(self.get_blueprint_owner_role(schema))
+                blueprints.append(self.get_blueprint_read_role(schema))
+                blueprints.append(self.get_blueprint_write_role(schema))
+            # otherwise, create only specified roles
+            else:
+                for schema_role in schema.schema_roles:
+                    if schema_role.lower() == "owner":
+                        blueprints.append(self.get_blueprint_owner_role(schema))
+                    if schema_role.lower() == "read":
+                        blueprints.append(self.get_blueprint_read_role(schema))
+                    if schema_role.lower() == "write":
+                        blueprints.append(self.get_blueprint_write_role(schema))
 
         return {str(bp.full_name): bp for bp in blueprints}
 


### PR DESCRIPTION
## Overview

By default, SnowDDL autogenerates 3 schema roles for every schema defined in the config:
* `<db>__<schema>__OWNER__S_ROLE`
* `<db>__<schema>__READ__S_ROLE`
* `<db>__<schema>__WRITE__S_ROLE`

Reference: https://docs.snowddl.com/guides/role-hierarchy#schema-roles

These roles are granted a number of pre-defined, low-level privileges

In some cases, these roles may not always be desired. This PR extends the `SchemaRoleResolver` to optionally skip role generation

## Changes
* Add `schema_roles` attribute to `SchemaBlueprint`. This should be a list of strings accepting values `["owner", "read", "write"]`
* Update `SchemaParser` to accept `schema_roles` attribute in YAML config
* Update `SchemaRoleResolver` to optionally skip generation of some schema roles based on the value set for `schema_roles` attribute in `SchemaBlueprint`