### PR TITLE
Adding ability for schema level sandbox param to override database sandbox param

### DIFF
--- a/snowddl/parser/schema.py
+++ b/snowddl/parser/schema.py
@@ -1,12 +1,7 @@
-from snowddl.blueprint import (
-    Grant,
-    ObjectType,
-    SchemaBlueprint,
-    SchemaIdent,
-    build_role_ident,
-)
+from snowddl.blueprint import SchemaBlueprint, SchemaIdent, Grant, ObjectType, build_role_ident
 from snowddl.parser.abc_parser import AbstractParser
 from snowddl.parser.database import database_json_schema
+
 
 # fmt: off
 schema_json_schema = {

--- a/snowddl/parser/schema.py
+++ b/snowddl/parser/schema.py
@@ -1,7 +1,12 @@
-from snowddl.blueprint import SchemaBlueprint, SchemaIdent, Grant, ObjectType, build_role_ident
+from snowddl.blueprint import (
+    Grant,
+    ObjectType,
+    SchemaBlueprint,
+    SchemaIdent,
+    build_role_ident,
+)
 from snowddl.parser.abc_parser import AbstractParser
 from snowddl.parser.database import database_json_schema
-
 
 # fmt: off
 schema_json_schema = {
@@ -93,7 +98,7 @@ class SchemaParser(AbstractParser):
                 combined_params = {
                     "is_transient": database_params.get("is_transient", False) or schema_params.get("is_transient", False),
                     "retention_time": schema_params.get("retention_time"),
-                    "is_sandbox": database_params.get("is_sandbox", False) or schema_params.get("is_sandbox", False),
+                    "is_sandbox": schema_params.get("is_sandbox", False) or database_params.get("is_sandbox", False),
                 }
 
                 database_name = database_path.name.upper()

--- a/snowddl/parser/schema.py
+++ b/snowddl/parser/schema.py
@@ -90,10 +90,14 @@ class SchemaParser(AbstractParser):
 
                 schema_params = self.parse_single_file(schema_path / "params.yaml", schema_json_schema)
 
+                is_schema_sandbox = schema_params.get("is_sandbox")
+                if is_schema_sandbox == None:
+                    is_schema_sandbox = database_params.get("is_sandbox", False)
+
                 combined_params = {
                     "is_transient": database_params.get("is_transient", False) or schema_params.get("is_transient", False),
                     "retention_time": schema_params.get("retention_time"),
-                    "is_sandbox": schema_params.get("is_sandbox", False) or database_params.get("is_sandbox", False),
+                    "is_sandbox": is_schema_sandbox,
                 }
 
                 database_name = database_path.name.upper()


### PR DESCRIPTION
Discussed here: https://github.com/littleK0i/SnowDDL/issues/140#issuecomment-2463005245

Enables user to define `is_sandbox` in schema level `params.yaml` which will override `is_sandbox` in database level `params.yaml`