### PR TITLE
Add workload identity support

### DIFF
--- a/snowddl/app/base.py
+++ b/snowddl/app/base.py
@@ -117,7 +117,7 @@ class BaseApp:
         )
         parser.add_argument(
             "--workload-identity-provider",
-            help="Workload identity provider (default: WORKLOAD_IDENTITY_PROVIDER env variable)",
+            help="Workload identity provider (default: SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER env variable)",
             default=environ.get("SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER"),
         )
         parser.add_argument(


### PR DESCRIPTION
I would like to propose `workload_identity` authenticator, which utilizes OIDC tokens to get access to Snowflake. Those tokens are exposed by CI runtimes (GH Actions/CircleCI). This way CI pipelines without any keys can access Snowflake.

Docs:
- https://docs.github.com/en/actions/concepts/security/openid-connect
- https://docs.snowflake.com/en/user-guide/workload-identity-federation

This way, you can allow the CI pipeline to access Snowflake like this:

```sql
ALTER USER SNOWDDL SET
    WORKLOAD_IDENTITY = (
        TYPE = OIDC,
        ISSUER = 'https://token.actions.githubusercontent.com',
        SUBJECT = 'repo:littleK0i/SnowDDL:environment:prod'
    );
```

GH actions snippet:
```yaml
name: ci
jobs:
  plan:
    runs-on: ubuntu-latest
    environment: prod
    permissions:
      contents: read
      id-token: write
    steps:
      ....
      - name: Run snowddl plan
        env:
          SNOWFLAKE_ACCOUNT: ${{ vars.SNOWFLAKE_ACCOUNT }}
          SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
          SNOWFLAKE_ROLE: ${{ vars.SNOWFLAKE_ROLE }}
          SNOWFLAKE_AUTHENTICATOR: "workload_identity"
          SNOWFLAKE_WORKLOAD_IDENTITY_PROVIDER: "oidc"
          SNOWFLAKE_AUDIENCE: "snowflakecomputing.com"
        run: |
          export SNOWFLAKE_WORKLOAD_IDENTITY_TOKEN=$(curl -sSL \
          -X GET "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=$SNOWFLAKE_AUDIENCE" \
          -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" | jq -r '.value')

          snowddl plan

```