### PR TITLE
Add test for ambiguous procedure overloading when changing arguments with DEFAULT

### DIFF
--- a/test/_config/step1/db1/sc1/procedure/pr005_pr1(varchar).yaml
+++ b/test/_config/step1/db1/sc1/procedure/pr005_pr1(varchar).yaml
@@ -1,0 +1,11 @@
+language: javascript
+
+arguments:
+  source: VARCHAR(255)
+
+returns: VARCHAR(255)
+
+body: |-
+  return source;
+
+comment: abc

--- a/test/_config/step2/db1/sc1/procedure/pr005_pr1(varchar,varchar).yaml
+++ b/test/_config/step2/db1/sc1/procedure/pr005_pr1(varchar,varchar).yaml
@@ -1,0 +1,14 @@
+language: javascript
+
+arguments:
+  source: VARCHAR(255)
+  target_table:
+    type: VARCHAR(255)
+    default: "'default_target'"
+
+returns: VARCHAR(255)
+
+body: |-
+  return source + ":" + TARGET_TABLE;
+
+comment: cde

--- a/test/procedure/pr005.py
+++ b/test/procedure/pr005.py
@@ -1,0 +1,52 @@
+from snowddl.blueprint import BaseDataType
+
+
+def test_step1(helper):
+    procedure_show = helper.show_procedure("db1", "sc1", "pr005_pr1")
+    procedure_dtypes = helper.dtypes_from_arguments(procedure_show["arguments"])
+
+    procedure_desc = helper.desc_procedure("db1", "sc1", "pr005_pr1", procedure_dtypes)
+
+    # Procedure exists with 1 VARCHAR argument
+    assert procedure_dtypes == [BaseDataType.VARCHAR]
+
+    assert procedure_desc["language"] == "JAVASCRIPT"
+
+    # Validate fact that short hash is present
+    assert procedure_show["description"].startswith("abc #")
+
+
+def test_step2(helper):
+    # Currently, changing from (VARCHAR) to (VARCHAR, VARCHAR DEFAULT ...) fails
+    # with Snowflake error 949: "Cannot overload PROCEDURE as it would cause
+    # ambiguous PROCEDURE overloading."
+    #
+    # This happens because SnowDDL runs CREATE before DROP. The new (VARCHAR, VARCHAR)
+    # signature with a DEFAULT on the second arg is ambiguous with the existing (VARCHAR)
+    # signature, so Snowflake rejects the CREATE. The old procedure is never dropped.
+    #
+    # As a result, the old procedure with 1 argument still exists unchanged.
+    procedure_show = helper.show_procedure("db1", "sc1", "pr005_pr1")
+    procedure_dtypes = helper.dtypes_from_arguments(procedure_show["arguments"])
+
+    # Old procedure still exists with original 1-arg signature
+    assert procedure_dtypes == [BaseDataType.VARCHAR]
+
+    # Old comment unchanged (the new procedure was never created)
+    assert procedure_show["description"].startswith("abc #")
+
+
+def test_step3(helper):
+    procedure_show = helper.show_procedure("db1", "sc1", "pr005_pr1")
+    procedure_dtypes = helper.dtypes_from_arguments(procedure_show["arguments"])
+
+    # The old (VARCHAR) procedure from step1 is STILL here as an orphan.
+    # Step2 failed to create the (VARCHAR,VARCHAR) replacement due to ambiguous
+    # overloading, so the old procedure was never dropped. Step3 has no pr005
+    # config, but since the schema cache may not know about this orphan
+    # (depends on test isolation), it can persist.
+    #
+    # Once the ambiguous overloading bug is fixed, step2 will succeed and
+    # this test should change to: assert procedure_show is None
+    assert procedure_dtypes == [BaseDataType.VARCHAR]
+    assert procedure_show["description"].startswith("abc #")


### PR DESCRIPTION
Documents issue #296: changing a procedure's argument list by adding a parameter with DEFAULT fails with Snowflake error 949 because the resolver runs create before drop.