### PR TITLE
Support account and database event table associations

### DIFF
--- a/snowddl/blueprint/blueprint.py
+++ b/snowddl/blueprint/blueprint.py
@@ -133,6 +133,7 @@ class DatabaseBlueprint(AbstractBlueprint):
     retention_time: Optional[int] = None
     external_volume: Optional[Ident] = None
     catalog: Optional[Ident] = None
+    event_table: Optional[SchemaObjectIdent] = None
     owner_database_write: List[IdentPattern] = []
     owner_database_read: List[IdentPattern] = []
     owner_schema_write: List[IdentPattern] = []

--- a/snowddl/config.py
+++ b/snowddl/config.py
@@ -6,6 +6,7 @@ from snowddl.blueprint import (
     AbstractIdentWithPrefix,
     AbstractPolicyReference,
     IdentPattern,
+    SchemaObjectIdent,
     ObjectType,
     PermissionModel,
     PermissionModelRuleset,
@@ -39,6 +40,7 @@ class SnowDDLConfig:
         self.blueprints: Dict[Type[T_Blueprint], Dict[str, T_Blueprint]] = defaultdict(dict)
         self.placeholders: Dict[str, Union[bool, float, int, str]] = {}
         self.permission_models: Dict[str, PermissionModel] = self._init_permission_models()
+        self.account_event_table: Optional[SchemaObjectIdent] = None
 
     def get_blueprints_by_type(self, cls: Type[T_Blueprint]) -> Dict[str, T_Blueprint]:
         return self.blueprints.get(cls, {})

--- a/snowddl/parser/account_params.py
+++ b/snowddl/parser/account_params.py
@@ -1,4 +1,4 @@
-from snowddl.blueprint import AccountParameterBlueprint, Ident
+from snowddl.blueprint import AccountParameterBlueprint, Ident, build_schema_object_ident
 from snowddl.parser.abc_parser import AbstractParser, ParsedFile
 
 
@@ -18,6 +18,15 @@ class AccountParameterParser(AbstractParser):
 
     def process_account_params(self, f: ParsedFile):
         for name, value in f.params.items():
+            if str(name).upper() == "EVENT_TABLE":
+                if len(value.split(".")) != 3:
+                    raise ValueError(
+                        f"Event table identifier [{value}] must use format [database.schema.event_table]"
+                    )
+
+                self.config.account_event_table = build_schema_object_ident(self.env_prefix, value, None, None)
+                continue
+
             bp = AccountParameterBlueprint(
                 full_name=Ident(name),
                 value=value,

--- a/snowddl/parser/database.py
+++ b/snowddl/parser/database.py
@@ -5,6 +5,7 @@ from snowddl.blueprint import (
     DatabaseIdent,
     Ident,
     IdentPattern,
+    build_schema_object_ident,
     build_share_read_ident,
 )
 from snowddl.parser.abc_parser import AbstractParser
@@ -28,6 +29,9 @@ database_json_schema = {
         },
         "catalog": {
             "type": "string",
+        },
+        "event_table": {
+            "type": "string"
         },
         "is_sandbox": {
             "type": "boolean"
@@ -102,6 +106,15 @@ class DatabaseParser(AbstractParser):
         for database_name in self.get_database_names():
             database_params = self.parse_single_entity_file(f"{database_name}/params", database_json_schema)
             database_permission_model_name = database_params.get("permission_model", self.config.DEFAULT_PERMISSION_MODEL).upper()
+            event_table = None
+
+            if event_table_name := database_params.get("event_table"):
+                if len(event_table_name.split(".")) not in (2, 3):
+                    raise ValueError(
+                        f"Event table identifier [{event_table_name}] must use format [schema.event_table] or [database.schema.event_table]"
+                    )
+
+                event_table = build_schema_object_ident(self.env_prefix, event_table_name, database_name, None)
 
             # fmt: off
             bp = DatabaseBlueprint(
@@ -111,6 +124,7 @@ class DatabaseParser(AbstractParser):
                 retention_time=database_params.get("retention_time", None),
                 external_volume=Ident(database_params.get("external_volume")) if database_params.get("external_volume") else None,
                 catalog=Ident(database_params.get("catalog")) if database_params.get("catalog") else None,
+                event_table=event_table,
                 is_sandbox=database_params.get("is_sandbox", False),
                 owner_database_write=[IdentPattern(p) for p in database_params.get("owner_database_write", [])],
                 owner_database_read=[IdentPattern(p) for p in database_params.get("owner_database_read", [])],

--- a/snowddl/resolver/event_table.py
+++ b/snowddl/resolver/event_table.py
@@ -1,9 +1,29 @@
-from snowddl.blueprint import EventTableBlueprint
-from snowddl.resolver.abc_schema_object_resolver import AbstractSchemaObjectResolver, ResolveResult, ObjectType
+from typing import Optional
+
+from snowddl.blueprint import DatabaseBlueprint, EventTableBlueprint
+from snowddl.resolver.abc_schema_object_resolver import AbstractSchemaObjectResolver, ObjectType, ResolveResult
 
 
 class EventTableResolver(AbstractSchemaObjectResolver):
     skip_on_empty_blueprints = True
+    _is_destroy_mode = False
+
+    def resolve(self):
+        self._is_destroy_mode = False
+        super().resolve()
+
+    def destroy(self):
+        self._is_destroy_mode = True
+        super().destroy()
+
+    def _pre_process(self):
+        self._unset_outdated_associations()
+
+    def _post_process(self):
+        if self._is_destroy_mode:
+            return
+
+        self._set_desired_associations()
 
     def get_object_type(self) -> ObjectType:
         return ObjectType.EVENT_TABLE
@@ -133,3 +153,74 @@ class EventTableResolver(AbstractSchemaObjectResolver):
             )
 
         return query
+
+    def _unset_outdated_associations(self):
+        account_row = self._get_account_event_table_row()
+
+        if self._should_unset_event_table(account_row, self.config.account_event_table, "ACCOUNT"):
+            self.engine.execute_unsafe_ddl(
+                "ALTER ACCOUNT UNSET EVENT_TABLE",
+                condition=self.engine.settings.execute_account_params,
+            )
+
+        for database_bp in self.config.get_blueprints_by_type(DatabaseBlueprint).values():
+            row = self._get_database_event_table_row(database_bp)
+
+            if self._should_unset_event_table(row, database_bp.event_table, "DATABASE"):
+                self.engine.execute_unsafe_ddl(
+                    "ALTER DATABASE {name:i} UNSET EVENT_TABLE",
+                    {
+                        "name": database_bp.full_name,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+
+    def _set_desired_associations(self):
+        account_row = self._get_account_event_table_row()
+
+        if self._should_set_event_table(account_row, self.config.account_event_table, "ACCOUNT"):
+            self.engine.execute_unsafe_ddl(
+                "ALTER ACCOUNT SET EVENT_TABLE = {name:i}",
+                {
+                    "name": self.config.account_event_table,
+                },
+                condition=self.engine.settings.execute_account_params,
+            )
+
+        for database_bp in self.config.get_blueprints_by_type(DatabaseBlueprint).values():
+            row = self._get_database_event_table_row(database_bp)
+
+            if self._should_set_event_table(row, database_bp.event_table, "DATABASE"):
+                self.engine.execute_unsafe_ddl(
+                    "ALTER DATABASE {database_name:i} SET EVENT_TABLE = {event_table_name:i}",
+                    {
+                        "database_name": database_bp.full_name,
+                        "event_table_name": database_bp.event_table,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+
+    def _get_account_event_table_row(self):
+        return self.engine.execute_meta("SHOW PARAMETERS LIKE 'EVENT_TABLE' FOR ACCOUNT").fetchone()
+
+    def _get_database_event_table_row(self, bp: DatabaseBlueprint):
+        return self.engine.execute_meta(
+            "SHOW PARAMETERS LIKE 'EVENT_TABLE' IN DATABASE {name:i}",
+            {
+                "name": bp.full_name,
+            },
+        ).fetchone()
+
+    def _should_unset_event_table(self, row: Optional[dict], desired_event_table, expected_level: str):
+        if row is None or row["level"] != expected_level:
+            return False
+
+        desired_matches = desired_event_table is not None and str(desired_event_table) == row["value"]
+
+        return desired_matches if self._is_destroy_mode else not desired_matches
+
+    def _should_set_event_table(self, row: Optional[dict], desired_event_table, expected_level: str):
+        if desired_event_table is None:
+            return False
+
+        return row is None or row["level"] != expected_level or str(desired_event_table) != row["value"]

--- a/test/_config/step1/db1/params.yaml
+++ b/test/_config/step1/db1/params.yaml
@@ -1,1 +1,2 @@
 comment: abc
+event_table: sc1.et001_et1

--- a/test/_config/step2/db1/params.yaml
+++ b/test/_config/step2/db1/params.yaml
@@ -1,0 +1,1 @@
+event_table: sc1.et002_et1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -177,6 +177,21 @@ class Helper:
 
         return cur.fetchone()
 
+    def show_account_parameters(self):
+        cur = self.execute("SHOW PARAMETERS FOR ACCOUNT")
+
+        return {r["key"]: r for r in cur}
+
+    def show_database_parameters(self, database):
+        cur = self.execute(
+            "SHOW PARAMETERS IN DATABASE {name:i}",
+            {
+                "name": SchemaIdent(self.env_prefix, database, "PUBLIC").database_full_name,
+            },
+        )
+
+        return {r["key"]: r for r in cur}
+
     def show_event_table(self, database, schema, name):
         cur = self.execute(
             "SHOW EVENT TABLES LIKE {table_name:lf} IN SCHEMA {schema_name:i}",

--- a/test/event_table/et003.py
+++ b/test/event_table/et003.py
@@ -1,0 +1,18 @@
+def test_step1(helper):
+    event_table_param = helper.show_database_parameters("db1")["EVENT_TABLE"]
+
+    assert event_table_param["value"] == f"{helper.env_prefix}DB1.SC1.ET001_ET1"
+    assert event_table_param["level"] == "DATABASE"
+
+
+def test_step2(helper):
+    event_table_param = helper.show_database_parameters("db1")["EVENT_TABLE"]
+
+    assert event_table_param["value"] == f"{helper.env_prefix}DB1.SC1.ET002_ET1"
+    assert event_table_param["level"] == "DATABASE"
+
+
+def test_step3(helper):
+    event_table_param = helper.show_database_parameters("db1")["EVENT_TABLE"]
+
+    assert event_table_param["level"] != "DATABASE"

--- a/test/event_table/event_table_unit.py
+++ b/test/event_table/event_table_unit.py
@@ -1,0 +1,148 @@
+import pytest
+
+from snowddl import SnowDDLConfig, SnowDDLFormatter
+from snowddl.blueprint import AccountParameterBlueprint, DatabaseBlueprint, DatabaseIdent, SchemaObjectIdent
+from snowddl.parser import AccountParameterParser, DatabaseParser
+from snowddl.parser._scanner import DirectoryScanner
+from snowddl.resolver import EventTableResolver
+from snowddl.settings import SnowDDLSettings
+
+
+class DummyEngine:
+    def __init__(self, meta_rows=None, execute_account_params=True, is_account_admin=True):
+        self.config = SnowDDLConfig(env_prefix="PYTEST__")
+        self.settings = SnowDDLSettings(
+            execute_safe_ddl=True,
+            execute_unsafe_ddl=True,
+            execute_account_params=execute_account_params,
+        )
+        self.context = DummyContext(is_account_admin=is_account_admin)
+        self.formatter = SnowDDLFormatter()
+        self.executed_sql = []
+        self.suggested_sql = []
+        self.meta_rows = meta_rows or {}
+
+    def execute_unsafe_ddl(self, sql, params=None, condition=True, file_stream=None):
+        if condition:
+            self.executed_sql.append(self.formatter.format_sql(sql, params))
+        else:
+            self.suggested_sql.append(self.formatter.format_sql(sql, params))
+
+    def execute_meta(self, sql, params=None):
+        return DummyCursor(self.meta_rows.get(self.formatter.format_sql(sql, params), []))
+
+
+class DummyCursor:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def fetchone(self):
+        if self.rows:
+            return self.rows[0]
+
+        return None
+
+
+class DummyContext:
+    def __init__(self, is_account_admin=True):
+        self.is_account_admin = is_account_admin
+
+
+def test_account_params_parser_stores_event_table_on_config(tmp_path):
+    (tmp_path / "account_params.yaml").write_text("timezone: UTC\nevent_table: db1.sc1.et1\n", encoding="utf-8")
+
+    config = SnowDDLConfig(env_prefix="PYTEST__")
+    parser = AccountParameterParser(config, DirectoryScanner(tmp_path))
+
+    parser.load_blueprints()
+
+    account_params = config.get_blueprints_by_type(AccountParameterBlueprint)
+
+    assert "TIMEZONE" in account_params
+    assert "EVENT_TABLE" not in account_params
+    assert str(config.account_event_table) == "PYTEST__DB1.SC1.ET1"
+
+
+def test_account_params_parser_rejects_non_fully_qualified_event_table(tmp_path):
+    (tmp_path / "account_params.yaml").write_text("event_table: sc1.et1\n", encoding="utf-8")
+
+    config = SnowDDLConfig(env_prefix="PYTEST__")
+    parser = AccountParameterParser(config, DirectoryScanner(tmp_path))
+
+    parser.load_blueprints()
+
+    assert len(parser.errors) == 1
+    assert "database.schema.event_table" in str(next(iter(parser.errors.values())))
+
+
+def test_database_parser_rejects_single_part_event_table_name(tmp_path):
+    db_dir = tmp_path / "db1"
+    db_dir.mkdir()
+    (db_dir / "params.yaml").write_text("event_table: et1\n", encoding="utf-8")
+
+    config = SnowDDLConfig(env_prefix="PYTEST__")
+    parser = DatabaseParser(config, DirectoryScanner(tmp_path))
+
+    with pytest.raises(ValueError, match="schema.event_table"):
+        parser.load_blueprints()
+
+
+def test_event_table_resolver_sets_desired_account_association():
+    engine = DummyEngine(
+        meta_rows={
+            "SHOW PARAMETERS LIKE 'EVENT_TABLE' FOR ACCOUNT": [
+                {"key": "EVENT_TABLE", "value": "SNOWFLAKE.TELEMETRY.EVENTS", "level": ""}
+            ]
+        },
+        execute_account_params=True,
+    )
+    engine.config.account_event_table = SchemaObjectIdent("PYTEST__", "DB1", "SC1", "ET1")
+
+    resolver = EventTableResolver(engine)
+    resolver._post_process()
+
+    assert engine.executed_sql == ['ALTER ACCOUNT SET EVENT_TABLE = "PYTEST__DB1"."SC1"."ET1"']
+
+
+def test_event_table_resolver_destroy_mode_unsets_but_does_not_reset_account_association():
+    engine = DummyEngine(
+        meta_rows={
+            "SHOW PARAMETERS LIKE 'EVENT_TABLE' FOR ACCOUNT": [
+                {"key": "EVENT_TABLE", "value": "PYTEST__DB1.SC1.ET1", "level": "ACCOUNT"}
+            ]
+        },
+        execute_account_params=True,
+    )
+    engine.config.account_event_table = SchemaObjectIdent("PYTEST__", "DB1", "SC1", "ET1")
+
+    resolver = EventTableResolver(engine)
+    resolver._is_destroy_mode = True
+
+    resolver._pre_process()
+    resolver._post_process()
+
+    assert engine.executed_sql == ['ALTER ACCOUNT UNSET EVENT_TABLE']
+
+
+def test_event_table_resolver_suggests_database_association_when_session_lacks_accountadmin():
+    engine = DummyEngine(
+        meta_rows={
+            "SHOW PARAMETERS LIKE 'EVENT_TABLE' FOR ACCOUNT": [],
+            "SHOW PARAMETERS LIKE 'EVENT_TABLE' IN DATABASE PYTEST__DB1": [
+                {"key": "EVENT_TABLE", "value": "SNOWFLAKE.TELEMETRY.EVENTS", "level": ""}
+            ],
+        },
+        is_account_admin=False,
+    )
+    engine.config.add_blueprint(
+        DatabaseBlueprint(
+            full_name=DatabaseIdent("PYTEST__", "DB1"),
+            event_table=SchemaObjectIdent("PYTEST__", "DB1", "SC1", "ET1"),
+        )
+    )
+
+    resolver = EventTableResolver(engine)
+    resolver._post_process()
+
+    assert engine.executed_sql == []
+    assert engine.suggested_sql == ['ALTER DATABASE "PYTEST__DB1" SET EVENT_TABLE = "PYTEST__DB1"."SC1"."ET1"']


### PR DESCRIPTION
## Summary

SnowDDL [supports event table](https://docs.snowddl.com/basic/yaml-configs/event-table) but doesn't support associate it with account / database. 
This PR adds the support, so one can configure `event_table` at database `params.yaml`, or `account_params.yaml`. The actual association is done by the event table resolver so at the time the account / database / table already exists.

[Association requires `ACCOUNTADMIN`](https://docs.snowflake.com/en/developer-guide/logging-tracing/event-table-setting-up#supported-objects) so in the case of database, suggested DDL is printed out if the user is not account admin. For account params, the existing rule (raise an error) is applied.

This PR is AI written but with several rounds of careful reviews and updates. I tested in our dev environment but without `ACCOUNTADMIN`. I'd expect the integration test to cover the `ACCOUNTADMIN` path.

It's my first PR to this project so anything out of expectations, let me know.

  ## What Changed

  - parse `event_table` from database `params.yaml`
  - parse `EVENT_TABLE` from `account_params.yaml`
  - apply/unset event table associations through `EventTableResolver`
  - suggest database association changes when `ACCOUNTADMIN` is not in session
  - add integration and targeted unit coverage for event table association behavior