### PR TITLE
Implement LOG_LEVEL, LOG_EVENT_LEVEL, METRIC_LEVEL, TRACE_LEVEL for DATABASE and SCHEMA

### DIFF
--- a/snowddl/blueprint/blueprint.py
+++ b/snowddl/blueprint/blueprint.py
@@ -134,6 +134,10 @@ class DatabaseBlueprint(AbstractBlueprint):
     external_volume: Optional[Ident] = None
     catalog: Optional[Ident] = None
     catalog_sync: Optional[Ident] = None
+    log_level: Optional[str] = None
+    log_event_level: Optional[str] = None
+    metric_level: Optional[str] = None
+    trace_level: Optional[str] = None
     event_table: Optional[SchemaObjectIdent] = None
     owner_database_write: List[IdentPattern] = []
     owner_database_read: List[IdentPattern] = []
@@ -365,6 +369,10 @@ class SchemaBlueprint(AbstractBlueprint):
     external_volume: Optional[Ident] = None
     catalog: Optional[Ident] = None
     catalog_sync: Optional[Ident] = None
+    log_level: Optional[str] = None
+    log_event_level: Optional[str] = None
+    metric_level: Optional[str] = None
+    trace_level: Optional[str] = None
     owner_database_write: List[IdentPattern] = []
     owner_database_read: List[IdentPattern] = []
     owner_schema_write: List[IdentPattern] = []

--- a/snowddl/parser/database.py
+++ b/snowddl/parser/database.py
@@ -35,11 +35,11 @@ database_json_schema = {
         },
         "log_level": {
             "type": "string",
-            "enum": ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG"]
+            "enum": ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"]
         },
         "log_event_level": {
             "type": "string",
-            "enum": ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG"]
+            "enum": ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"]
         },
         "metric_level": {
             "type": "string",

--- a/snowddl/parser/database.py
+++ b/snowddl/parser/database.py
@@ -33,6 +33,22 @@ database_json_schema = {
         "catalog_sync": {
             "type": "string",
         },
+        "log_level": {
+            "type": "string",
+            "enum": ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG"]
+        },
+        "log_event_level": {
+            "type": "string",
+            "enum": ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG"]
+        },
+        "metric_level": {
+            "type": "string",
+            "enum": ["ALL", "NONE"]
+        },
+        "trace_level": {
+            "type": "string",
+            "enum": ["OFF", "ON_EVENT", "ALWAYS"]
+        },
         "event_table": {
             "type": "string",
         },
@@ -119,6 +135,10 @@ class DatabaseParser(AbstractParser):
                 external_volume=Ident(database_params.get("external_volume")) if database_params.get("external_volume") else None,
                 catalog=Ident(database_params.get("catalog")) if database_params.get("catalog") else None,
                 catalog_sync=Ident(database_params.get("catalog_sync")) if database_params.get("catalog_sync") else None,
+                log_level=database_params.get("log_level", None),
+                log_event_level=database_params.get("log_event_level", None),
+                metric_level=database_params.get("metric_level", None),
+                trace_level=database_params.get("trace_level", None),
                 event_table=build_schema_object_ident(self.env_prefix, database_params.get("event_table"), database_name) if database_params.get("event_table") else None,
                 is_sandbox=database_params.get("is_sandbox", False),
                 owner_database_write=[IdentPattern(p) for p in database_params.get("owner_database_write", [])],

--- a/snowddl/parser/schema.py
+++ b/snowddl/parser/schema.py
@@ -1,15 +1,14 @@
 from snowddl.blueprint import (
     AccountGrant,
     AccountObjectIdent,
-    SchemaBlueprint,
-    SchemaIdent,
     Ident,
     IdentPattern,
+    SchemaBlueprint,
+    SchemaIdent,
     build_share_read_ident,
 )
 from snowddl.parser.abc_parser import AbstractParser
 from snowddl.parser.database import database_json_schema
-
 
 # fmt: off
 schema_json_schema = {
@@ -38,11 +37,11 @@ schema_json_schema = {
         },
         "log_level": {
             "type": "string",
-            "enum": ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG"]
+            "enum": ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"]
         },
         "log_event_level": {
             "type": "string",
-            "enum": ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG"]
+            "enum": ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"]
         },
         "metric_level": {
             "type": "string",

--- a/snowddl/parser/schema.py
+++ b/snowddl/parser/schema.py
@@ -36,6 +36,22 @@ schema_json_schema = {
         "catalog_sync": {
             "type": "string",
         },
+        "log_level": {
+            "type": "string",
+            "enum": ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG"]
+        },
+        "log_event_level": {
+            "type": "string",
+            "enum": ["OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG"]
+        },
+        "metric_level": {
+            "type": "string",
+            "enum": ["ALL", "NONE"]
+        },
+        "trace_level": {
+            "type": "string",
+            "enum": ["OFF", "ON_EVENT", "ALWAYS"]
+        },
         "owner_database_read": {
             "type": "array",
             "items": {
@@ -118,6 +134,10 @@ class SchemaParser(AbstractParser):
                     "external_volume": schema_params.get("external_volume", database_params.get("external_volume")),
                     "catalog": schema_params.get("catalog", database_params.get("catalog")),
                     "catalog_sync": schema_params.get("catalog_sync", database_params.get("catalog_sync")),
+                    "log_level": schema_params.get("log_level", database_params.get("log_level")),
+                    "log_event_level": schema_params.get("log_event_level", database_params.get("log_event_level")),
+                    "metric_level": schema_params.get("metric_level", database_params.get("metric_level")),
+                    "trace_level": schema_params.get("trace_level", database_params.get("trace_level")),
                 }
 
                 # fmt: off
@@ -130,6 +150,10 @@ class SchemaParser(AbstractParser):
                     external_volume=Ident(combined_params.get("external_volume")) if combined_params.get("external_volume") else None,
                     catalog=Ident(combined_params.get("catalog")) if combined_params.get("catalog") else None,
                     catalog_sync=Ident(combined_params.get("catalog_sync")) if combined_params.get("catalog_sync") else None,
+                    log_level=combined_params.get("log_level", None),
+                    log_event_level=combined_params.get("log_event_level", None),
+                    metric_level=combined_params.get("metric_level", None),
+                    trace_level=combined_params.get("trace_level", None),
                     owner_database_write=[IdentPattern(p) for p in schema_params.get("owner_database_write", [])],
                     owner_database_read=[IdentPattern(p) for p in schema_params.get("owner_database_read", [])],
                     owner_schema_write=[IdentPattern(p) for p in schema_params.get("owner_schema_write", [])],

--- a/snowddl/resolver/database.py
+++ b/snowddl/resolver/database.py
@@ -131,6 +131,90 @@ class DatabaseResolver(AbstractResolver):
 
             result = ResolveResult.ALTER
 
+        if bp.log_level != database_params.get("LOG_LEVEL"):
+            if bp.log_level:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER DATABASE {full_name:i} SET LOG_LEVEL = {log_level}",
+                    {
+                        "full_name": bp.full_name,
+                        "log_level": bp.log_level,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+            else:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER DATABASE {full_name:i} UNSET LOG_LEVEL",
+                    {
+                        "full_name": bp.full_name,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+
+            result = ResolveResult.ALTER
+
+        if bp.log_event_level != database_params.get("LOG_EVENT_LEVEL"):
+            if bp.log_event_level:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER DATABASE {full_name:i} SET LOG_EVENT_LEVEL = {log_event_level}",
+                    {
+                        "full_name": bp.full_name,
+                        "log_event_level": bp.log_event_level,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+            else:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER DATABASE {full_name:i} UNSET LOG_EVENT_LEVEL",
+                    {
+                        "full_name": bp.full_name,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+
+            result = ResolveResult.ALTER
+
+        if bp.metric_level != database_params.get("METRIC_LEVEL"):
+            if bp.metric_level:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER DATABASE {full_name:i} SET METRIC_LEVEL = {metric_level}",
+                    {
+                        "full_name": bp.full_name,
+                        "metric_level": bp.metric_level,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+            else:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER DATABASE {full_name:i} UNSET METRIC_LEVEL",
+                    {
+                        "full_name": bp.full_name,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+
+            result = ResolveResult.ALTER
+
+        if bp.trace_level != database_params.get("TRACE_LEVEL"):
+            if bp.trace_level:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER DATABASE {full_name:i} SET TRACE_LEVEL = {trace_level}",
+                    {
+                        "full_name": bp.full_name,
+                        "trace_level": bp.trace_level,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+            else:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER DATABASE {full_name:i} UNSET TRACE_LEVEL",
+                    {
+                        "full_name": bp.full_name,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+
+            result = ResolveResult.ALTER
+
         if bp.comment != row["comment"]:
             self.engine.execute_unsafe_ddl(
                 "ALTER DATABASE {full_name:i} SET COMMENT = {comment}",

--- a/snowddl/resolver/database.py
+++ b/snowddl/resolver/database.py
@@ -139,7 +139,6 @@ class DatabaseResolver(AbstractResolver):
                         "full_name": bp.full_name,
                         "log_level": bp.log_level,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
             else:
                 self.engine.execute_unsafe_ddl(
@@ -147,7 +146,6 @@ class DatabaseResolver(AbstractResolver):
                     {
                         "full_name": bp.full_name,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
 
             result = ResolveResult.ALTER
@@ -160,7 +158,6 @@ class DatabaseResolver(AbstractResolver):
                         "full_name": bp.full_name,
                         "log_event_level": bp.log_event_level,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
             else:
                 self.engine.execute_unsafe_ddl(
@@ -168,7 +165,6 @@ class DatabaseResolver(AbstractResolver):
                     {
                         "full_name": bp.full_name,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
 
             result = ResolveResult.ALTER
@@ -181,7 +177,6 @@ class DatabaseResolver(AbstractResolver):
                         "full_name": bp.full_name,
                         "metric_level": bp.metric_level,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
             else:
                 self.engine.execute_unsafe_ddl(
@@ -189,7 +184,6 @@ class DatabaseResolver(AbstractResolver):
                     {
                         "full_name": bp.full_name,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
 
             result = ResolveResult.ALTER
@@ -202,7 +196,6 @@ class DatabaseResolver(AbstractResolver):
                         "full_name": bp.full_name,
                         "trace_level": bp.trace_level,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
             else:
                 self.engine.execute_unsafe_ddl(
@@ -210,7 +203,6 @@ class DatabaseResolver(AbstractResolver):
                     {
                         "full_name": bp.full_name,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
 
             result = ResolveResult.ALTER

--- a/snowddl/resolver/schema.py
+++ b/snowddl/resolver/schema.py
@@ -126,6 +126,90 @@ class SchemaResolver(AbstractResolver):
 
             result = ResolveResult.ALTER
 
+        if bp.log_level != schema_params.get("LOG_LEVEL"):
+            if bp.log_level:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER SCHEMA {full_name:i} SET LOG_LEVEL = {log_level}",
+                    {
+                        "full_name": bp.full_name,
+                        "log_level": bp.log_level,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+            else:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER SCHEMA {full_name:i} UNSET LOG_LEVEL",
+                    {
+                        "full_name": bp.full_name,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+
+            result = ResolveResult.ALTER
+
+        if bp.log_event_level != schema_params.get("LOG_EVENT_LEVEL"):
+            if bp.log_event_level:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER SCHEMA {full_name:i} SET LOG_EVENT_LEVEL = {log_event_level}",
+                    {
+                        "full_name": bp.full_name,
+                        "log_event_level": bp.log_event_level,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+            else:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER SCHEMA {full_name:i} UNSET LOG_EVENT_LEVEL",
+                    {
+                        "full_name": bp.full_name,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+
+            result = ResolveResult.ALTER
+
+        if bp.metric_level != schema_params.get("METRIC_LEVEL"):
+            if bp.metric_level:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER SCHEMA {full_name:i} SET METRIC_LEVEL = {metric_level}",
+                    {
+                        "full_name": bp.full_name,
+                        "metric_level": bp.metric_level,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+            else:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER SCHEMA {full_name:i} UNSET METRIC_LEVEL",
+                    {
+                        "full_name": bp.full_name,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+
+            result = ResolveResult.ALTER
+
+        if bp.trace_level != schema_params.get("TRACE_LEVEL"):
+            if bp.trace_level:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER SCHEMA {full_name:i} SET TRACE_LEVEL = {trace_level}",
+                    {
+                        "full_name": bp.full_name,
+                        "trace_level": bp.trace_level,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+            else:
+                self.engine.execute_unsafe_ddl(
+                    "ALTER SCHEMA {full_name:i} UNSET TRACE_LEVEL",
+                    {
+                        "full_name": bp.full_name,
+                    },
+                    condition=self.engine.context.is_account_admin,
+                )
+
+            result = ResolveResult.ALTER
+
         if bp.comment != row["comment"]:
             self.engine.execute_unsafe_ddl(
                 "ALTER SCHEMA {full_name:i} SET COMMENT = {comment}",

--- a/snowddl/resolver/schema.py
+++ b/snowddl/resolver/schema.py
@@ -134,7 +134,6 @@ class SchemaResolver(AbstractResolver):
                         "full_name": bp.full_name,
                         "log_level": bp.log_level,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
             else:
                 self.engine.execute_unsafe_ddl(
@@ -142,7 +141,6 @@ class SchemaResolver(AbstractResolver):
                     {
                         "full_name": bp.full_name,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
 
             result = ResolveResult.ALTER
@@ -155,7 +153,6 @@ class SchemaResolver(AbstractResolver):
                         "full_name": bp.full_name,
                         "log_event_level": bp.log_event_level,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
             else:
                 self.engine.execute_unsafe_ddl(
@@ -163,7 +160,6 @@ class SchemaResolver(AbstractResolver):
                     {
                         "full_name": bp.full_name,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
 
             result = ResolveResult.ALTER
@@ -176,7 +172,6 @@ class SchemaResolver(AbstractResolver):
                         "full_name": bp.full_name,
                         "metric_level": bp.metric_level,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
             else:
                 self.engine.execute_unsafe_ddl(
@@ -184,7 +179,6 @@ class SchemaResolver(AbstractResolver):
                     {
                         "full_name": bp.full_name,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
 
             result = ResolveResult.ALTER
@@ -197,7 +191,6 @@ class SchemaResolver(AbstractResolver):
                         "full_name": bp.full_name,
                         "trace_level": bp.trace_level,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
             else:
                 self.engine.execute_unsafe_ddl(
@@ -205,7 +198,6 @@ class SchemaResolver(AbstractResolver):
                     {
                         "full_name": bp.full_name,
                     },
-                    condition=self.engine.context.is_account_admin,
                 )
 
             result = ResolveResult.ALTER

--- a/test/_config/step1/db1/params.yaml
+++ b/test/_config/step1/db1/params.yaml
@@ -1,2 +1,7 @@
 event_table: sc1.et003_et1
+retention_time: 5
+log_level: DEBUG
+log_event_level: WARN
+metric_level: ALL
+trace_level: ALWAYS
 comment: abc

--- a/test/_config/step1/db1/sc1/params.yaml
+++ b/test/_config/step1/db1/sc1/params.yaml
@@ -1,3 +1,10 @@
+retention_time: 1
+comment: abc
+log_level: INFO
+log_event_level: WARN
+metric_level: ALL
+trace_level: ON_EVENT
+
 owner_integration_usage:
   - test_notification_integration
 

--- a/test/_config/step2/db1/params.yaml
+++ b/test/_config/step2/db1/params.yaml
@@ -1,1 +1,4 @@
 event_table: sc1.et003_et2
+retention_time: 7
+log_level: INFO
+metric_level: NONE

--- a/test/_config/step2/db1/sc1/params.yaml
+++ b/test/_config/step2/db1/sc1/params.yaml
@@ -1,3 +1,8 @@
+retention_time: 2
+comment: cde
+metric_level: NONE
+trace_level: OFF
+
 owner_integration_usage:
   - test_notification_integration
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -167,11 +167,42 @@ class Helper:
 
         return cur.fetchone()
 
+    def show_database(self, database):
+        cur = self.execute(
+            "SHOW DATABASES LIKE {database_name:lf}",
+            {
+                "database_name": DatabaseIdent(self.env_prefix, database),
+            },
+        )
+
+        return cur.fetchone()
+
+    def show_schema(self, database, schema):
+        cur = self.execute(
+            "SHOW SCHEMAS LIKE {schema_name:lf} IN DATABASE {database_name:i}",
+            {
+                "database_name": DatabaseIdent(self.env_prefix, database),
+                "schema_name": Ident(schema),
+            },
+        )
+
+        return cur.fetchone()
+
     def show_database_parameters(self, database):
         cur = self.execute(
             "SHOW PARAMETERS IN DATABASE {name:i}",
             {
                 "name": DatabaseIdent(self.env_prefix, database),
+            },
+        )
+
+        return {r["key"]: r for r in cur}
+
+    def show_schema_parameters(self, database, schema):
+        cur = self.execute(
+            "SHOW PARAMETERS IN SCHEMA {name:i}",
+            {
+                "name": SchemaIdent(self.env_prefix, database, schema),
             },
         )
 

--- a/test/database_params/dp001.py
+++ b/test/database_params/dp001.py
@@ -1,0 +1,49 @@
+def test_step1(helper):
+    db = helper.show_database("db1")
+    db_params = helper.show_database_parameters("db1")
+
+    assert int(db["retention_time"]) == 5
+    assert db["comment"] == "abc"
+
+    assert db_params["LOG_LEVEL"]["level"] == "DATABASE"
+    assert db_params["LOG_LEVEL"]["value"] == "DEBUG"
+
+    assert db_params["LOG_EVENT_LEVEL"]["level"] == "DATABASE"
+    assert db_params["LOG_EVENT_LEVEL"]["value"] == "WARN"
+
+    assert db_params["METRIC_LEVEL"]["level"] == "DATABASE"
+    assert db_params["METRIC_LEVEL"]["value"] == "ALL"
+
+    assert db_params["TRACE_LEVEL"]["level"] == "DATABASE"
+    assert db_params["TRACE_LEVEL"]["value"] == "ALWAYS"
+
+
+def test_step2(helper):
+    db = helper.show_database("db1")
+    db_params = helper.show_database_parameters("db1")
+
+    assert int(db["retention_time"]) == 7
+    assert not db["comment"]
+
+    assert db_params["LOG_LEVEL"]["level"] == "DATABASE"
+    assert db_params["LOG_LEVEL"]["value"] == "INFO"
+
+    assert db_params["LOG_EVENT_LEVEL"]["level"] != "DATABASE"
+
+    assert db_params["METRIC_LEVEL"]["level"] == "DATABASE"
+    assert db_params["METRIC_LEVEL"]["value"] == "NONE"
+
+    assert db_params["TRACE_LEVEL"]["level"] != "DATABASE"
+
+
+def test_step3(helper):
+    db = helper.show_database("db1")
+    db_params = helper.show_database_parameters("db1")
+
+    assert int(db["retention_time"]) == 7  # not unset, persists from step2
+    assert not db["comment"]
+
+    assert db_params["LOG_LEVEL"]["level"] != "DATABASE"
+    assert db_params["LOG_EVENT_LEVEL"]["level"] != "DATABASE"
+    assert db_params["METRIC_LEVEL"]["level"] != "DATABASE"
+    assert db_params["TRACE_LEVEL"]["level"] != "DATABASE"

--- a/test/schema_params/sp001.py
+++ b/test/schema_params/sp001.py
@@ -1,0 +1,48 @@
+def test_step1(helper):
+    sc = helper.show_schema("db1", "sc1")
+    sc_params = helper.show_schema_parameters("db1", "sc1")
+
+    assert int(sc["retention_time"]) == 1
+    assert sc["comment"] == "abc"
+
+    assert sc_params["LOG_LEVEL"]["level"] == "SCHEMA"
+    assert sc_params["LOG_LEVEL"]["value"] == "INFO"
+
+    assert sc_params["LOG_EVENT_LEVEL"]["level"] == "SCHEMA"
+    assert sc_params["LOG_EVENT_LEVEL"]["value"] == "WARN"
+
+    assert sc_params["METRIC_LEVEL"]["level"] == "SCHEMA"
+    assert sc_params["METRIC_LEVEL"]["value"] == "ALL"
+
+    assert sc_params["TRACE_LEVEL"]["level"] == "SCHEMA"
+    assert sc_params["TRACE_LEVEL"]["value"] == "ON_EVENT"
+
+
+def test_step2(helper):
+    sc = helper.show_schema("db1", "sc1")
+    sc_params = helper.show_schema_parameters("db1", "sc1")
+
+    assert int(sc["retention_time"]) == 2
+    assert sc["comment"] == "cde"
+
+    assert sc_params["LOG_LEVEL"]["level"] != "SCHEMA"
+    assert sc_params["LOG_EVENT_LEVEL"]["level"] != "SCHEMA"
+
+    assert sc_params["METRIC_LEVEL"]["level"] == "SCHEMA"
+    assert sc_params["METRIC_LEVEL"]["value"] == "NONE"
+
+    assert sc_params["TRACE_LEVEL"]["level"] == "SCHEMA"
+    assert sc_params["TRACE_LEVEL"]["value"] == "OFF"
+
+
+def test_step3(helper):
+    sc = helper.show_schema("db1", "sc1")
+    sc_params = helper.show_schema_parameters("db1", "sc1")
+
+    assert int(sc["retention_time"]) == 2  # not unset, persists from step2
+    assert not sc["comment"]
+
+    assert sc_params["LOG_LEVEL"]["level"] != "SCHEMA"
+    assert sc_params["LOG_EVENT_LEVEL"]["level"] != "SCHEMA"
+    assert sc_params["METRIC_LEVEL"]["level"] != "SCHEMA"
+    assert sc_params["TRACE_LEVEL"]["level"] != "SCHEMA"


### PR DESCRIPTION
## Summary

Mostly pattern matching existing database params.

- Adds `LOG_LEVEL`, `LOG_EVENT_LEVEL`, `METRIC_LEVEL`, `TRACE_LEVEL` parameters to `DatabaseBlueprint` and `SchemaBlueprint`
- Schema params inherit from database if not explicitly overridden (same pattern as `EXTERNAL_VOLUME`/`CATALOG`) *Is this desired?* Can also just rely on snowflake falling back to database params.
- DDL is executed only when the session role has ACCOUNTADMIN (`condition=self.engine.context.is_account_admin`), otherwise output as suggested DDL

## Test plan

- [ ] `test/database_params/dp001.py` — 3-step test covering all 4 telemetry params, `comment`, and `retention_time` at database level
- [ ] `test/schema_params/sp001.py` — 3-step test covering all 4 telemetry params, `comment`, and `retention_time` at schema level
- [ ] New `show_database`, `show_schema`, `show_schema_parameters` helpers added to `conftest.py`