### PR TITLE
Address SYSDATE() DEFAULT column false drift detection

### DIFF
--- a/snowddl/resolver/hybrid_table.py
+++ b/snowddl/resolver/hybrid_table.py
@@ -314,5 +314,8 @@ class HybridTableResolver(AbstractSchemaObjectResolver):
         if isinstance(bp_default, SchemaObjectIdent):
             # This cannot be formatted properly with double-quotes ("), Snowflake strips it from DEFAULT value returned by DESC TABLE
             return f"{bp_default}.NEXTVAL"
+        if isinstance(bp_default, str) and bp_default.upper().replace(" ", "") == "SYSDATE()":
+            # Snowflake normalizes SYSDATE() into this canonical expression
+            return "CAST(CONVERT_TIMEZONE('UTC', CAST(CURRENT_TIMESTAMP() AS TIMESTAMP_TZ(9))) AS TIMESTAMP_NTZ(9))"
 
         return bp_default

--- a/snowddl/resolver/table.py
+++ b/snowddl/resolver/table.py
@@ -687,5 +687,8 @@ class TableResolver(AbstractSchemaObjectResolver):
         if isinstance(bp_default, SchemaObjectIdent):
             # This cannot be formatted properly with double-quotes ("), Snowflake strips it from DEFAULT value returned by DESC TABLE
             return f"{bp_default}.NEXTVAL"
+        if isinstance(bp_default, str) and bp_default.upper().replace(" ", "") == "SYSDATE()":
+            # Snowflake normalizes SYSDATE() into this canonical expression
+            return "CAST(CONVERT_TIMEZONE('UTC', CAST(CURRENT_TIMESTAMP() AS TIMESTAMP_TZ(9))) AS TIMESTAMP_NTZ(9))"
 
         return bp_default

--- a/test/_config/step1/db1/sc1/table/tb002_tb1.yaml
+++ b/test/_config/step1/db1/sc1/table/tb002_tb1.yaml
@@ -5,3 +5,6 @@ columns:
   name:
     type: VARCHAR(255)
     default: "'John Doe'"
+  register_ts:
+    type: TIMESTAMP_NTZ(9)
+    default: SYSDATE()

--- a/test/_config/step2/db1/sc1/table/tb002_tb1.yaml
+++ b/test/_config/step2/db1/sc1/table/tb002_tb1.yaml
@@ -6,6 +6,9 @@ columns:
   name:
     type: VARCHAR(255) NOT NULL
     comment: "abc"
+  register_ts:
+    type: TIMESTAMP_NTZ(9)
+    default: SYSDATE()
 
 comment: "abc"
 cluster_by: ["id"]

--- a/test/table/tb002.py
+++ b/test/table/tb002.py
@@ -12,6 +12,7 @@ def test_step1(helper):
     # Defaults are set
     assert "TB002_SQ1" in cols["ID"]["default"]
     assert cols["NAME"]["default"]
+    assert "CAST(CONVERT_TIMEZONE('UTC', CAST(CURRENT_TIMESTAMP() AS TIMESTAMP_TZ(9))) AS TIMESTAMP_NTZ(9))" in cols["REGISTER_TS"]["default"]
 
     # Other params are off
     assert not table["cluster_by"]
@@ -37,6 +38,9 @@ def test_step2(helper):
     # Default value is gone
     assert not cols["NAME"]["default"]
 
+    # SYSDATE() default persists unchanged
+    assert "CAST(CONVERT_TIMEZONE('UTC', CAST(CURRENT_TIMESTAMP() AS TIMESTAMP_TZ(9))) AS TIMESTAMP_NTZ(9))" in cols["REGISTER_TS"]["default"]
+
     # Other params are on
     assert table["cluster_by"]
     assert table["change_tracking"] == "ON"
@@ -58,6 +62,9 @@ def test_step3(helper):
     # Defaults are empty again
     assert not cols["ID"]["default"]
     assert not cols["NAME"]["default"]
+
+    # Column was dropped
+    assert "REGISTER_TS" not in cols
 
     # Other params are off again
     assert not table["cluster_by"]


### PR DESCRIPTION
Snowflake normalizes SYSDATE() expression into an entirely different canonical expression: CAST(CONVERT_TIMEZONE(UTC, CAST(CURRENT_TIMESTAMP() AS TIMESTAMP_TZ(9))) AS TIMESTAMP_NTZ(9)). This caused SnowDDL to assume that there was drift in DDL and flag tables with columns that had defaults of SYSDATE(), even though functionally they are identical to what is on Snowflake.

This PR includes an additional normalization to table.py and hybrid_table.py resolvers when the default value is SYSDATE(), and also some additional tests to tb002.py.

Fixes #334 