### PR TITLE
Exclude SNOWSERVICE-* integrations from name-conformance warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Added workaround for Snowflake-managed `SNOWSERVICE-*` integrations (auto-created for Snowpark Container Services / Cortex features) appearing as "does not conform to SnowDDL standards" warnings in `SHOW GRANTS` output.
+
 ## [0.67.4] - 2026-06-12
 
 - Added workaround for Snowflake bug with Cortex Search objects bleeding into `SHOW GRANTS` output.

--- a/snowddl/resolver/abc_role_resolver.py
+++ b/snowddl/resolver/abc_role_resolver.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from re import compile
+from re import IGNORECASE, compile
 from typing import List, Optional, Tuple, Union
 
 from snowddl.blueprint import (
@@ -23,6 +23,7 @@ from snowddl.resolver.abc_resolver import AbstractResolver, ResolveResult, Objec
 
 
 cortex_search_object_re = compile(r"^.+\._CORTEX_SEARCH_.+_[0-9A-F]{8}_[0-9A-F]{4}_[0-9A-F]{4}_[0-9A-F]{4}_[0-9A-F]{12}$")
+snowservice_integration_re = compile(r"^SNOWSERVICE-\d+-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", IGNORECASE)
 
 
 class AbstractRoleResolver(AbstractResolver):
@@ -100,6 +101,11 @@ class AbstractRoleResolver(AbstractResolver):
 
             # Snowflake bug: phantom objects from CORTEX SEARCH appear in grants, but nowhere else
             if "._CORTEX_SEARCH_" in str(r["name"]) and cortex_search_object_re.match(r["name"]):
+                continue
+
+            # Snowflake-managed integration auto-created for Snowpark Container Services / Cortex features
+            # It has no blueprint in SnowDDL and cannot be created, renamed or dropped by SnowDDL
+            if object_type == ObjectType.INTEGRATION and snowservice_integration_re.match(str(r["name"])):
                 continue
 
             if object_type == ObjectType.ACCOUNT:


### PR DESCRIPTION
## Summary
- Snowflake auto-creates account-level integrations named `SNOWSERVICE-<id>-<uuid>` for Snowpark Container Services / Cortex features. They appear in `SHOW GRANTS TO ROLE` output but have no SnowDDL blueprint (`INTEGRATION` is grants-only, per `object_type.py`), so SnowDDL can never create, rename, or drop them.
- Today they trigger `Detected INTEGRATION with name [...] which does not conform to SnowDDL standards, please rename or drop it manually`, which is misleading since there's nothing to rename/drop from SnowDDL's side.
- Adds a regex exclusion in `get_existing_role_grants`, following the same pattern as the existing `_CORTEX_SEARCH_` workaround for phantom Snowflake-managed objects.

## Test plan
- [ ] `ast.parse` / import sanity-checked locally (no unit test harness exercises live `SHOW GRANTS` output for this resolver; the existing `_CORTEX_SEARCH_` workaround likewise ships without a dedicated test)
- [ ] Verified against a Snowflake account with `SNOWSERVICE-*` integrations that the warning no longer appears after this change