### PR TITLE
Support granting external database roles (e.g. SNOWFLAKE.CORTEX_USER) to technical roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Added support for granting database roles not managed by SnowDDL config (e.g. `SNOWFLAKE.CORTEX_USER`) to technical roles. A `DATABASE_ROLE:USAGE` grant pattern with a fully-qualified name and no wildcards now falls back to a direct `GRANT DATABASE ROLE ... TO ROLE ...` when the pattern does not match any database role blueprint.
+
 ## [0.67.5] - 206-07-07
 
 - Added workaround for Snowflake-managed `SNOWSERVICE-*` integrations (auto-created for Snowpark Container Services / Cortex features) appearing as "does not conform to SnowDDL standards" warnings in `SHOW GRANTS` output.

--- a/snowddl/blueprint/__init__.py
+++ b/snowddl/blueprint/__init__.py
@@ -89,6 +89,7 @@ from .ident_builder import (
     build_future_grant_name_ident,
     build_default_namespace_ident,
     build_application_role_ident,
+    build_external_database_role_ident,
     build_share_read_ident,
 )
 from .ident_pattern import IdentPattern

--- a/snowddl/blueprint/grant.py
+++ b/snowddl/blueprint/grant.py
@@ -69,6 +69,16 @@ class GrantPattern(BaseModelWithConfig):
     on: ObjectType
     pattern: IdentPattern
 
+    def is_external_database_role_pattern(self) -> bool:
+        # Fully-qualified database role owned outside of SnowDDL config (e.g. SNOWFLAKE.CORTEX_USER)
+        # Only USAGE can be granted role-to-role, and wildcards cannot be resolved without blueprints
+        return (
+            self.on == ObjectType.DATABASE_ROLE
+            and self.privilege == "USAGE"
+            and not self.pattern.is_complex_pattern
+            and "." in self.pattern.pattern
+        )
+
     def is_matching_grant(self, grant: Grant):
         if self.privilege != grant.privilege:
             return False

--- a/snowddl/blueprint/ident_builder.py
+++ b/snowddl/blueprint/ident_builder.py
@@ -120,6 +120,12 @@ def build_application_role_ident(application_role_name: str) -> ApplicationRoleI
     return ApplicationRoleIdent("", *application_role_name.split(".", 2))
 
 
+def build_external_database_role_ident(database_role_name: str) -> DatabaseRoleIdent:
+    # External database roles (e.g. SNOWFLAKE.CORTEX_USER) are global objects
+    # No env prefix for global objects, matches build_grant_name_ident() output for SHOW GRANTS
+    return DatabaseRoleIdent("", *database_role_name.split(".", 2))
+
+
 def build_share_read_ident(share_name: str) -> Union[Ident, DatabaseRoleIdent]:
     if "." in share_name:
         # Shares are global, so database roles inside shares are global as well

--- a/snowddl/resolver/technical_role.py
+++ b/snowddl/resolver/technical_role.py
@@ -1,4 +1,12 @@
-from snowddl.blueprint import ObjectType, RoleBlueprint, SchemaBlueprint, TechnicalRoleBlueprint, Grant, FutureGrant
+from snowddl.blueprint import (
+    ObjectType,
+    RoleBlueprint,
+    SchemaBlueprint,
+    TechnicalRoleBlueprint,
+    Grant,
+    FutureGrant,
+    build_external_database_role_ident,
+)
 from snowddl.resolver.abc_role_resolver import AbstractRoleResolver
 
 
@@ -17,9 +25,20 @@ class TechnicalRoleResolver(AbstractRoleResolver):
         future_grants = []
 
         for grant_pattern in technical_role_bp.grant_patterns:
-            for obj_bp in self.config.get_blueprints_by_type_and_pattern(
-                grant_pattern.on.blueprint_cls, grant_pattern.pattern
-            ).values():
+            matched_bps = self.config.get_blueprints_by_type_and_pattern(grant_pattern.on.blueprint_cls, grant_pattern.pattern)
+
+            if not matched_bps and grant_pattern.is_external_database_role_pattern():
+                # Database role not managed by SnowDDL config (e.g. SNOWFLAKE.CORTEX_USER)
+                grants.append(
+                    Grant(
+                        privilege=grant_pattern.privilege,
+                        on=grant_pattern.on,
+                        name=build_external_database_role_ident(grant_pattern.pattern.pattern),
+                    ),
+                )
+                continue
+
+            for obj_bp in matched_bps.values():
                 grants.append(
                     Grant(
                         privilege=grant_pattern.privilege,

--- a/snowddl/validator/technical_role.py
+++ b/snowddl/validator/technical_role.py
@@ -13,10 +13,13 @@ class TechnicalRoleValidator(AbstractValidator):
     def _validate_grant_patterns(self, bp: TechnicalRoleBlueprint):
         for grant_pattern in bp.grant_patterns:
             if not self.config.get_blueprints_by_type_and_pattern(grant_pattern.on.blueprint_cls, grant_pattern.pattern):
-                raise ValueError(
-                    f"Technical role [{bp.full_name}] grant pattern [{grant_pattern.pattern}] "
-                    f"does not match any objects of type [{grant_pattern.on.name}]"
-                )
+                # Fully-qualified database roles owned outside of SnowDDL config (e.g. SNOWFLAKE.CORTEX_USER)
+                # cannot be validated against config, existence is checked by Snowflake on apply
+                if not grant_pattern.is_external_database_role_pattern():
+                    raise ValueError(
+                        f"Technical role [{bp.full_name}] grant pattern [{grant_pattern.pattern}] "
+                        f"does not match any objects of type [{grant_pattern.on.name}]"
+                    )
 
             if grant_pattern.privilege == "ALL":
                 raise ValueError(

--- a/test/_config/step1/technical_role.yaml
+++ b/test/_config/step1/technical_role.yaml
@@ -15,3 +15,8 @@ pm001_tr1:
       - pm001_db1
     VIEW:SELECT:
       - pm001*.*
+
+tr001_tr1:
+  grants:
+    DATABASE_ROLE:USAGE:
+      - SNOWFLAKE.CORTEX_USER

--- a/test/_config/step2/technical_role.yaml
+++ b/test/_config/step2/technical_role.yaml
@@ -4,3 +4,8 @@ pm001_tr2:
       - pm001*
     SCHEMA:USAGE:
       - pm001*.*
+
+tr001_tr1:
+  grants:
+    DATABASE_ROLE:USAGE:
+      - SNOWFLAKE.CORTEX_USER

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -445,6 +445,26 @@ class Helper:
 
         return cur.fetchone()
 
+    def show_grants_to_role(self, name):
+        cur = self.execute(
+            "SHOW GRANTS TO ROLE {name:i}",
+            {
+                "name": AccountObjectIdent(self.env_prefix, name),
+            },
+        )
+
+        return cur.fetchall()
+
+    def show_role(self, name):
+        cur = self.execute(
+            "SHOW ROLES LIKE {name:lf}",
+            {
+                "name": AccountObjectIdent(self.env_prefix, name),
+            },
+        )
+
+        return cur.fetchone()
+
     def show_network_policy(self, name):
         # SHOW NETWORK POLICIES does not support LIKE natively
         cur = self.execute("SHOW NETWORK POLICIES")

--- a/test/technical_role/tr001.py
+++ b/test/technical_role/tr001.py
@@ -1,0 +1,18 @@
+def test_step1(helper):
+    grants = helper.show_grants_to_role("tr001_tr1__T_ROLE")
+
+    assert any(
+        g["privilege"] == "USAGE" and g["granted_on"] == "DATABASE_ROLE" and g["name"] == "SNOWFLAKE.CORTEX_USER" for g in grants
+    )
+
+
+def test_step2(helper):
+    grants = helper.show_grants_to_role("tr001_tr1__T_ROLE")
+
+    assert any(
+        g["privilege"] == "USAGE" and g["granted_on"] == "DATABASE_ROLE" and g["name"] == "SNOWFLAKE.CORTEX_USER" for g in grants
+    )
+
+
+def test_step3(helper):
+    assert helper.show_role("tr001_tr1__T_ROLE") is None

--- a/tests_unit/test_technical_role_external_database_role.py
+++ b/tests_unit/test_technical_role_external_database_role.py
@@ -1,0 +1,122 @@
+from types import SimpleNamespace
+
+import pytest
+
+from snowddl.blueprint import (
+    DatabaseRoleBlueprint,
+    DatabaseRoleIdent,
+    Grant,
+    GrantPattern,
+    IdentPattern,
+    ObjectType,
+    TechnicalRoleBlueprint,
+    build_external_database_role_ident,
+    build_grant_name_ident,
+    build_role_ident,
+)
+from snowddl.config import SnowDDLConfig
+from snowddl.resolver.technical_role import TechnicalRoleResolver
+from snowddl.validator.technical_role import TechnicalRoleValidator
+
+ENV_PREFIX = "PYTEST__"
+
+
+def build_technical_role_blueprint(config, grant_patterns):
+    return TechnicalRoleBlueprint(
+        full_name=build_role_ident(config.env_prefix, "CORTEX", config.TECHNICAL_ROLE_SUFFIX),
+        grant_patterns=grant_patterns,
+    )
+
+
+def build_grant_pattern(privilege="USAGE", on=ObjectType.DATABASE_ROLE, pattern="SNOWFLAKE.CORTEX_USER"):
+    return GrantPattern(privilege=privilege, on=on, pattern=IdentPattern(pattern))
+
+
+class TestIsExternalDatabaseRolePattern:
+    def test_accepts_fully_qualified_usage_pattern(self):
+        assert build_grant_pattern().is_external_database_role_pattern() is True
+
+    def test_rejects_other_object_type(self):
+        assert (
+            build_grant_pattern(on=ObjectType.DATABASE, pattern="SNOWFLAKE.CORTEX_USER").is_external_database_role_pattern()
+            is False
+        )
+
+    def test_rejects_non_usage_privilege(self):
+        assert build_grant_pattern(privilege="MONITOR").is_external_database_role_pattern() is False
+
+    def test_rejects_complex_pattern(self):
+        assert build_grant_pattern(pattern="SNOWFLAKE.*").is_external_database_role_pattern() is False
+
+    def test_rejects_name_without_database(self):
+        assert build_grant_pattern(pattern="CORTEX_USER").is_external_database_role_pattern() is False
+
+
+class TestTechnicalRoleResolver:
+    def build_resolver(self, config):
+        return TechnicalRoleResolver(SimpleNamespace(config=config))
+
+    def test_external_database_role_grant(self):
+        config = SnowDDLConfig(env_prefix="PYTEST__")
+        technical_role_bp = build_technical_role_blueprint(config, [build_grant_pattern()])
+
+        role_bp = self.build_resolver(config).transform_blueprint(technical_role_bp)
+
+        assert role_bp.grants == [
+            Grant(
+                privilege="USAGE",
+                on=ObjectType.DATABASE_ROLE,
+                name=DatabaseRoleIdent("", "SNOWFLAKE", "CORTEX_USER"),
+            )
+        ]
+        assert str(role_bp.grants[0].name) == "SNOWFLAKE.CORTEX_USER"
+
+    def test_managed_database_role_takes_precedence(self):
+        config = SnowDDLConfig(env_prefix="PYTEST__")
+        database_role_bp = DatabaseRoleBlueprint(full_name=DatabaseRoleIdent(config.env_prefix, "ANALYTICS", "READER"))
+        config.add_blueprint(database_role_bp)
+
+        technical_role_bp = build_technical_role_blueprint(config, [build_grant_pattern(pattern="ANALYTICS.READER")])
+
+        role_bp = self.build_resolver(config).transform_blueprint(technical_role_bp)
+
+        assert len(role_bp.grants) == 1
+        assert role_bp.grants[0].name == database_role_bp.full_name
+        assert str(role_bp.grants[0].name).startswith(config.env_prefix)
+
+    def test_unmatched_wildcard_pattern_produces_no_grants(self):
+        config = SnowDDLConfig(env_prefix="PYTEST__")
+        technical_role_bp = build_technical_role_blueprint(config, [build_grant_pattern(pattern="SNOWFLAKE.*")])
+
+        role_bp = self.build_resolver(config).transform_blueprint(technical_role_bp)
+
+        assert role_bp.grants == []
+
+    def test_round_trip_with_show_grants_ident(self):
+        # SHOW GRANTS parsing must produce an ident equal to the config-side ident,
+        # otherwise SnowDDL would revoke and re-grant on every apply
+        config_side = build_external_database_role_ident("SNOWFLAKE.CORTEX_USER")
+        show_grants_side = build_grant_name_ident(ENV_PREFIX, "SNOWFLAKE.CORTEX_USER", ObjectType.DATABASE_ROLE)
+
+        assert config_side == show_grants_side
+
+
+class TestTechnicalRoleValidator:
+    def validate(self, config, grant_patterns):
+        bp = build_technical_role_blueprint(config, grant_patterns)
+        TechnicalRoleValidator(config).validate_blueprint(bp)
+
+    def test_accepts_external_database_role(self):
+        self.validate(SnowDDLConfig(env_prefix="PYTEST__"), [build_grant_pattern()])
+
+    def test_rejects_unmatched_wildcard_pattern(self):
+        with pytest.raises(ValueError, match="does not match any objects"):
+            self.validate(SnowDDLConfig(env_prefix="PYTEST__"), [build_grant_pattern(pattern="SNOWFLAKE.*")])
+
+    def test_rejects_unmatched_name_without_database(self):
+        with pytest.raises(ValueError, match="does not match any objects"):
+            self.validate(SnowDDLConfig(env_prefix="PYTEST__"), [build_grant_pattern(pattern="CORTEX_USER")])
+
+    def test_rejects_non_usage_privilege_on_unmatched_pattern(self):
+        with pytest.raises(ValueError, match="does not match any objects"):
+            self.validate(SnowDDLConfig(env_prefix="PYTEST__"), [build_grant_pattern(privilege="MONITOR")])


### PR DESCRIPTION
## Problem

There is currently no config path to grant a database role owned outside of SnowDDL config — such as `SNOWFLAKE.CORTEX_USER` — to a technical role:

- `grants: { "DATABASE_ROLE:USAGE": [SNOWFLAKE.CORTEX_USER] }` fails validation because the pattern matches no `DatabaseRoleBlueprint`.
- `global_roles` on business roles only accepts single-part role names (database roles were supported in 0.31.0 and removed in 0.37.0).
- If the grant is created manually, SnowDDL revokes it on the next apply.

## Change

A `DATABASE_ROLE:USAGE` grant pattern on a technical role now falls back to a direct `GRANT DATABASE ROLE ... TO ROLE ...` when **all** of the following hold:

- the pattern matches no database role blueprint in config,
- the privilege is `USAGE` (the only privilege supported for role-to-role grants),
- the pattern contains no wildcards (nothing to resolve without blueprints),
- the name is fully qualified (`DB.ROLE`).

Managed database roles are unaffected — the blueprint path takes precedence whenever a pattern matches. Unmatched wildcard patterns, unqualified names, and non-USAGE privileges still fail validation exactly as before.

The grant ident is built with an empty env prefix (same treatment as `build_share_read_ident`, since external database roles are global objects), so it round-trips against `SHOW GRANTS TO ROLE` output and plans stay idempotent.

Example config:

```yaml
# technical_role.yml
cortex_tr1:
  grants:
    DATABASE_ROLE:USAGE:
      - SNOWFLAKE.CORTEX_USER
```

produces:

```sql
GRANT DATABASE ROLE "SNOWFLAKE"."CORTEX_USER" TO ROLE "<env_prefix>CORTEX_TR1__T_ROLE"
```

No new config keys and no schema changes; `create_grant` / `drop_grant` in `abc_role_resolver.py` already render `GRANT/REVOKE DATABASE ROLE`.

## Tests

- `tests_unit/test_technical_role_external_database_role.py` — new pure unit tests (no Snowflake connection): the `GrantPattern.is_external_database_role_pattern` predicate, resolver fallback, managed-blueprint precedence, validator accept/reject cases, and a round-trip check that the config-side ident equals the ident parsed from `SHOW GRANTS` (guards against a perpetual revoke/re-grant loop). Run with `pytest tests_unit/`.
- `test/technical_role/tr001.py` + step1/step2 fixtures — integration test asserting `SHOW GRANTS TO ROLE` contains the `SNOWFLAKE.CORTEX_USER` grant (CORTEX_USER exists in every account), and that the role is dropped in step3.
- Verified end-to-end offline: parser → validator → resolver produces exactly the grant above; `ruff` and `black` (line-length 130) pass on changed files.