### PR TITLE
Skip policy references pointing at session temporary objects

### DIFF
--- a/snowddl/resolver/abc_schema_object_resolver.py
+++ b/snowddl/resolver/abc_schema_object_resolver.py
@@ -20,6 +20,47 @@ class AbstractSchemaObjectResolver(AbstractResolver):
     def get_existing_objects_in_schema(self, schema: dict):
         pass
 
+    def is_policy_ref_droppable(self, existing_ref: dict):
+        # POLICY_REFERENCES reports references from every session, including session-scoped temporary
+        # objects belonging to other sessions. Those objects are not durable, are not managed by SnowDDL,
+        # and cannot be altered from here at all — the ALTER fails with "does not exist or not authorized".
+        #
+        # SHOW OBJECTS is session-scoped, so a temporary object of another session is simply absent from
+        # the output, while a temporary object of the current session is reported with a TEMP kind.
+        cur = self.engine.execute_meta(
+            "SHOW OBJECTS LIKE {name:lf} IN SCHEMA {database:i}.{schema:i}",
+            {
+                "name": existing_ref["name"],
+                "database": existing_ref["database"],
+                "schema": existing_ref["schema"],
+            },
+        )
+
+        for r in cur:
+            if r["name"] != existing_ref["name"]:
+                continue
+
+            if "TEMP" in str(r["kind"]):
+                self.engine.logger.debug(
+                    f"Skipped policy reference on temporary object "
+                    f"[{existing_ref['database']}.{existing_ref['schema']}.{existing_ref['name']}]"
+                )
+
+                return False
+
+            return True
+
+        # Not visible in this session: a temporary object of another session, or an object which was
+        # dropped while its reference lingers. Warned rather than skipped silently, since the same
+        # outcome would hide a real reference on an object type missing from SHOW OBJECTS output.
+        self.engine.logger.warning(
+            f"Skipped policy reference on object "
+            f"[{existing_ref['database']}.{existing_ref['schema']}.{existing_ref['name']}], "
+            f"which does not exist in the current session"
+        )
+
+        return False
+
     def _resolve_drop(self):
         tasks = {}
 

--- a/snowddl/resolver/aggregation_policy.py
+++ b/snowddl/resolver/aggregation_policy.py
@@ -166,6 +166,9 @@ class AggregationPolicyResolver(AbstractSchemaObjectResolver):
 
         # Remove remaining policy references which no longer exist in blueprint
         for existing_ref in existing_policy_refs.values():
+            if not self.is_policy_ref_droppable(existing_ref):
+                continue
+
             # TODO: consider use case when object switches to another aggregation policy resolved in parallel
             self.engine.execute_unsafe_ddl(
                 "ALTER {object_type:r} {database:i}.{schema:i}.{name:i} UNSET AGGREGATION POLICY",
@@ -186,6 +189,9 @@ class AggregationPolicyResolver(AbstractSchemaObjectResolver):
         existing_policy_refs = self._get_existing_policy_refs(policy_name)
 
         for existing_ref in existing_policy_refs.values():
+            if not self.is_policy_ref_droppable(existing_ref):
+                continue
+
             # TODO: consider use case when object switches to another aggregation policy resolved in parallel
             self.engine.execute_unsafe_ddl(
                 "ALTER {object_type:r} {database:i}.{schema:i}.{name:i} UNSET AGGREGATION POLICY",

--- a/snowddl/resolver/join_policy.py
+++ b/snowddl/resolver/join_policy.py
@@ -174,6 +174,9 @@ class JoinPolicyResolver(AbstractSchemaObjectResolver):
 
         # Remove remaining policy references which no longer exist in blueprint
         for existing_ref in existing_policy_refs.values():
+            if not self.is_policy_ref_droppable(existing_ref):
+                continue
+
             self.engine.execute_unsafe_ddl(
                 "ALTER {object_type:r} {database:i}.{schema:i}.{name:i} UNSET JOIN POLICY",
                 {
@@ -193,6 +196,9 @@ class JoinPolicyResolver(AbstractSchemaObjectResolver):
         existing_policy_refs = self._get_existing_policy_refs(policy_name)
 
         for existing_ref in existing_policy_refs.values():
+            if not self.is_policy_ref_droppable(existing_ref):
+                continue
+
             self.engine.execute_unsafe_ddl(
                 "ALTER {object_type:r} {database:i}.{schema:i}.{name:i} UNSET JOIN POLICY",
                 {

--- a/snowddl/resolver/masking_policy.py
+++ b/snowddl/resolver/masking_policy.py
@@ -188,6 +188,9 @@ class MaskingPolicyResolver(AbstractSchemaObjectResolver):
 
         # Remove remaining policy references which no longer exist in blueprint
         for existing_ref in existing_policy_refs.values():
+            if not self.is_policy_ref_droppable(existing_ref):
+                continue
+
             self.engine.execute_unsafe_ddl(
                 "ALTER {object_type:r} {database:i}.{schema:i}.{name:i} MODIFY COLUMN {first_column:i} UNSET MASKING POLICY",
                 {
@@ -208,6 +211,9 @@ class MaskingPolicyResolver(AbstractSchemaObjectResolver):
         existing_policy_refs = self._get_existing_policy_refs(policy_name)
 
         for existing_ref in existing_policy_refs.values():
+            if not self.is_policy_ref_droppable(existing_ref):
+                continue
+
             self.engine.execute_unsafe_ddl(
                 "ALTER {object_type:r} {database:i}.{schema:i}.{name:i} MODIFY COLUMN {first_column:i} UNSET MASKING POLICY",
                 {

--- a/snowddl/resolver/projection_policy.py
+++ b/snowddl/resolver/projection_policy.py
@@ -149,6 +149,9 @@ class ProjectionPolicyResolver(AbstractSchemaObjectResolver):
 
         # Remove remaining policy references which no longer exist in blueprint
         for existing_ref in existing_policy_refs.values():
+            if not self.is_policy_ref_droppable(existing_ref):
+                continue
+
             # TODO: consider use case when object switches to another projection policy resolved in parallel
             self.engine.execute_unsafe_ddl(
                 "ALTER {object_type:r} {database:i}.{schema:i}.{name:i} MODIFY COLUMN {column:i} UNSET PROJECTION POLICY",
@@ -170,6 +173,9 @@ class ProjectionPolicyResolver(AbstractSchemaObjectResolver):
         existing_policy_refs = self._get_existing_policy_refs(policy_name)
 
         for existing_ref in existing_policy_refs.values():
+            if not self.is_policy_ref_droppable(existing_ref):
+                continue
+
             # TODO: consider use case when object switches to another projection policy resolved in parallel
             self.engine.execute_unsafe_ddl(
                 "ALTER {object_type:r} {database:i}.{schema:i}.{name:i} MODIFY COLUMN {column:i} UNSET PROJECTION POLICY",

--- a/snowddl/resolver/row_access_policy.py
+++ b/snowddl/resolver/row_access_policy.py
@@ -193,6 +193,9 @@ class RowAccessPolicyResolver(AbstractSchemaObjectResolver):
 
         # Remove remaining policy references which no longer exist in blueprint
         for existing_ref in existing_policy_refs.values():
+            if not self.is_policy_ref_droppable(existing_ref):
+                continue
+
             self.engine.execute_unsafe_ddl(
                 "ALTER {object_type:r} {database:i}.{schema:i}.{name:i} DROP ROW ACCESS POLICY {policy_name:i}",
                 {
@@ -213,6 +216,9 @@ class RowAccessPolicyResolver(AbstractSchemaObjectResolver):
         existing_policy_refs = self._get_existing_policy_refs(policy_name)
 
         for existing_ref in existing_policy_refs.values():
+            if not self.is_policy_ref_droppable(existing_ref):
+                continue
+
             self.engine.execute_unsafe_ddl(
                 "ALTER {object_type:r} {database:i}.{schema:i}.{name:i} DROP ROW ACCESS POLICY {policy_name:i}",
                 {


### PR DESCRIPTION
### Problem

`snowflake.information_schema.policy_references()` reports references from **every** session, including session-scoped temporary objects owned by other sessions. `_get_existing_policy_refs()` treats any such reference that is absent from the blueprint as drift, so SnowDDL plans a `DROP`/`UNSET` against a temporary object it can neither see nor alter:

```
SQL compilation error: View 'MY_DB.MY_SCHEMA.MY_MODEL__DBT_TMP' does not exist or not authorized.
```

The environment can then never converge, and with `--detailed-exitcode` the run keeps returning 2.

### How it happens in practice

dbt is the reliable way to hit this. A dbt model configured with `row_access_policy` builds its incremental `__dbt_tmp` relation through `snowflake__create_view_as_with_temp_flag`, which emits the policy clause on that **temporary view** too:

```sql
create or replace temporary view my_db.my_schema.my_model__dbt_tmp ... with row access policy ...
```

For the seconds a model takes to build, `policy_references()` carries an extra `__DBT_TMP` row — so any SnowDDL run overlapping a dbt run can plan the impossible DDL. Worse, a dbt session killed mid-build (OOM, evicted pod) leaves the reference behind after the temporary view is gone; in our account the orphan survived ~3h before Snowflake purged it, blocking every deploy in between. `apply` cannot clear it either, since dropping a policy reference is unsafe DDL.

### Change

Before dropping a policy reference, check whether the referenced object is a durable object visible to the current session. `SHOW OBJECTS` is session-scoped, which makes it a natural discriminator:

| Referenced object | `SHOW OBJECTS` result | Reference dropped |
| --- | --- | --- |
| Durable table / view | `kind = TABLE` / `VIEW` | yes |
| Temporary object, current session | `kind = TEMPORARY` / `TEMP VIEW` | no (debug log) |
| Temporary object, another session | absent | no (**warning**) |
| Object already dropped | absent | no (**warning**) |

The not-visible case warns rather than skipping silently, so this cannot quietly hide a real reference on an object type that turns out to be missing from `SHOW OBJECTS` output.

`is_policy_ref_droppable()` lives on `AbstractSchemaObjectResolver` and is called from the two drop paths (`_apply_policy_refs`'s leftover loop and `_drop_policy_refs`) of the five policy resolvers whose references are schema objects: row access, masking, aggregation, projection, join. Authentication and network policies reference users/accounts and are untouched.

**Cost:** the probe runs only on the drop path, which is empty in a converged environment — steady-state runs issue no additional queries. References matched to a blueprint are never probed.

### Verification

- All six branches of `is_policy_ref_droppable()` exercised against a stubbed engine (durable table, durable view, own-session `TEMP VIEW`, own-session `TEMPORARY`, absent object, and a `LIKE` over-match where `_` wildcards match a different object name — the exact-name comparison rejects it). The `:lf` formatter escapes `_`/`%`, verified against a live account.
- Patched vs. unpatched `plan` against our Enterprise dev account (`--include-object-types ROW_ACCESS_POLICY`, ~40 references across the policies): identical output, 0 suggested DDL. This confirms no regression, but note it does not exercise a live drift-drop, since the environment was converged at the time — the drop-still-happens path is covered by the stub test above.
- `ruff check` on the touched files reports only the pre-existing `I001` import-order finding, unchanged from `master`. Formatted with `black --line-length 130`.

I did not add an integration test: reproducing the primary case needs a second concurrent session holding a temporary object with a policy attached, which the current `test/` harness has no way to express. Happy to add one if you can suggest a shape that fits.

CHANGELOG left alone for you to fold into the release entry.
