### PR TITLE
Fix GRANT ... ON HYBRID TABLE failing with Unsupported feature 'UNKNOWN'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Fixed `GRANT ... ON HYBRID TABLE` statements failing with `Unsupported feature 'UNKNOWN'`. Snowflake does not accept `HYBRID TABLE` as a securable object type in `GRANT`/`REVOKE` statements; the generic `TABLE` keyword must be used instead, even though `HYBRID TABLE` is correct for `CREATE`/`ALTER`/`DESC`. Added `singular_for_grant: TABLE` to the `HYBRID_TABLE` object type, following the existing precedent for `EXTERNAL_ACCESS_INTEGRATION`.
+
 ## [0.67.6] - 2026-07-24
 
 - Fixed detection of NUMBER data type changes which involve precision only and can be processed with ALTER TABLE instead of REPLACE TABLE (thanks to @TB99930).

--- a/snowddl/blueprint/object_type.py
+++ b/snowddl/blueprint/object_type.py
@@ -142,6 +142,7 @@ class ObjectType(Enum):
         "singular": "HYBRID TABLE",
         "plural": "HYBRID TABLES",
         "singular_for_ref": "TABLE",
+        "singular_for_grant": "TABLE",
         "is_future_grant_supported": True,
         "blueprint_cls": "HybridTableBlueprint",
     }


### PR DESCRIPTION
## Summary

Direct grants on a Hybrid Table (e.g. `HYBRID_TABLE:SELECT: [...]` in a `technical_role`/`business_role`/`database_role` config) fail during `apply`:

```
GRANT SELECT ON HYBRID TABLE "DB"."SCHEMA"."ALERTS_HT" TO ROLE "SOME_ROLE"

Unsupported feature 'UNKNOWN'.
```

This is not a SnowDDL config issue -- Snowflake's `GRANT`/`REVOKE` syntax does not accept `HYBRID TABLE` as a securable object type, only the generic `TABLE` keyword:

> To grant privileges on hybrid tables, use the standard `TABLE` or `TABLES` keyword. You cannot specify `HYBRID TABLE` or `HYBRID TABLES`.

(from Snowflake's GRANT privilege docs / hybrid table limitations page)

`HYBRID TABLE` is still the correct keyword for `CREATE`/`ALTER`/`DESC`, which is presumably why `object_type.py` never needed a `singular_for_grant` override for it before. This mirrors the existing `EXTERNAL_ACCESS_INTEGRATION` entry, which already has `singular_for_grant: INTEGRATION` distinct from its own `singular` for the same reason.

## Fix

Add `"singular_for_grant": "TABLE"` to the `HYBRID_TABLE` entry in `snowddl/blueprint/object_type.py`. This only affects the keyword used when building `GRANT`/`REVOKE` SQL (`grant.on.singular_for_grant`); `CREATE`/`ALTER`/`DESC` statements keep using `HYBRID TABLE` via `singular`/`singular_for_ref`, which are unaffected.

## Out of scope

Future grants (`GRANT ... ON FUTURE HYBRID TABLES IN SCHEMA ...`) may have an analogous problem, but there's currently no `plural_for_grant`-style override mechanism for future/all grants in `abc_role_resolver.py` (`on_future.plural` is used directly). Introducing that is a larger change and isn't needed to fix the direct-grant case reported here, so I left it out of this PR.

## Test plan

- [x] Confirmed via source: `TechnicalRoleResolver.transform_blueprint` and the grant SQL builder in `abc_role_resolver.py` both read `grant.on.singular_for_grant`, so this one field change is sufficient to fix direct grants.
- [x] `ruff check` / `black --check` on the changed file: no new findings introduced (pre-existing `RUF012` warnings on the `Enum` class are unchanged, 54 before and after).
- [ ] Not run against a live Snowflake account -- I don't have credentials for this repo's test account. The existing `test/hybrid_table/ht001.py` fixtures don't currently exercise a direct `HYBRID_TABLE:` grant in `technical_role.yaml`/`business_role.yaml`, so there's no existing regression test covering this path; happy to add one if a maintainer can point me at how CI credentials are provisioned for external contributors.