### PR TITLE
Add depends_on support to FUNCTION objects

### DIFF
--- a/snowddl/blueprint/blueprint.py
+++ b/snowddl/blueprint/blueprint.py
@@ -226,7 +226,7 @@ class ForeignKeyBlueprint(SchemaObjectBlueprint):
     ref_columns: List[Ident]
 
 
-class FunctionBlueprint(SchemaObjectBlueprint):
+class FunctionBlueprint(SchemaObjectBlueprint, DependsOnMixin):
     full_name: SchemaObjectIdentWithArgs
     language: str
     body: Optional[str] = None

--- a/snowddl/parser/function.py
+++ b/snowddl/parser/function.py
@@ -118,6 +118,13 @@ function_json_schema = {
                 "type": "string"
             },
         },
+        "depends_on": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 1
+        },
         "comment": {
             "type": "string"
         }
@@ -162,6 +169,9 @@ class FunctionParser(AbstractParser):
             handler=f.params.get("handler"),
             external_access_integrations=self.get_external_access_integrations(f),
             secrets=self.get_secrets(f),
+            depends_on=set(
+                build_schema_object_ident(self.env_prefix, v, f.database, f.schema) for v in f.params.get("depends_on", [])
+            ),
             comment=f.params.get("comment"),
         )
 

--- a/test/_config/step1/db1/sc1/function/fn012_fn1().yaml
+++ b/test/_config/step1/db1/sc1/function/fn012_fn1().yaml
@@ -1,0 +1,6 @@
+language: SQL
+
+returns: BOOLEAN
+
+body: |-
+  SELECT TRUE

--- a/test/_config/step1/db1/sc1/function/fn012_fn2().yaml
+++ b/test/_config/step1/db1/sc1/function/fn012_fn2().yaml
@@ -1,0 +1,9 @@
+language: SQL
+
+returns: BOOLEAN
+
+depends_on:
+  - fn012_fn1()
+
+body: |-
+  SELECT ${{ env_prefix }}db1.sc1.fn012_fn1()

--- a/test/function/fn012.py
+++ b/test/function/fn012.py
@@ -1,0 +1,21 @@
+# fn012_fn2 calls fn012_fn1 in its body, and declares it via "depends_on".
+# Snowflake binds function bodies at CREATE time, so fn012_fn1 must exist
+# before fn012_fn2 is created, or CREATE FUNCTION fails with "does not exist".
+# Without "depends_on" both functions land in the same resolver batch and
+# are created concurrently, racing on which one Snowflake sees first.
+
+
+def test_step1(helper):
+    function_1_show = helper.show_function("db1", "sc1", "fn012_fn1")
+    function_2_show = helper.show_function("db1", "sc1", "fn012_fn2")
+
+    assert function_1_show
+    assert function_2_show
+
+
+def test_step3(helper):
+    function_1_show = helper.show_function("db1", "sc1", "fn012_fn1")
+    function_2_show = helper.show_function("db1", "sc1", "fn012_fn2")
+
+    assert function_1_show is None
+    assert function_2_show is None


### PR DESCRIPTION
## Summary
- `FunctionBlueprint` now mixes in `DependsOnMixin`, so FUNCTION objects support an optional `depends_on` list, the same convention `view`/`task`/`dynamic_table` already use.
- `FunctionParser` accepts `depends_on: [...]` in function YAML and resolves each entry via the existing `build_schema_object_ident` helper, which already understands the `NAME(ARGTYPES)` syntax functions need.

## Why
`CREATE FUNCTION` binds identifiers referenced in a SQL UDF body at creation time (not lazily at call time). `FunctionBlueprint` had no `DependsOnMixin`, so every FUNCTION in a schema lands in one resolver batch and gets created concurrently through a thread pool (`_process_tasks` in `abc_resolver.py` submits every task in a batch and iterates in completion order, not submission order). A function that calls a sibling function created in the same deploy races on which one Snowflake resolves first, and fails with `Unknown user-defined function ...` / `does not exist or not authorized` whenever the caller wins the race.

Hit this in production: a new zero-arg function calling another new zero-arg function in the same schema failed non-deterministically across separate deploy attempts of the same release tag.

## Relation to #336
This is intentionally narrower than #336 ("Support depends_on between Views, Dynamic Tables and UDFs"), which asks for cross-type dependency graphs (view <-> dynamic table <-> UDF) and drew pushback about review complexity once dependency trees span multiple nested object types.

This PR only adds `depends_on` **within** the FUNCTION object type, matching the design boundary stated in that thread: "everything runs in predictable sequential order, and dependency tree applies only within the same object type." VIEW, TASK, and DYNAMIC_TABLE already have this same-type `depends_on`; FUNCTION was simply missing it. No new cross-type resolution mechanism, no added complexity for the multi-type case discussed in #336.

## Test plan
- [x] Verified the resolver's batching algorithm now puts a dependency in its own earlier batch instead of racing in the same batch (isolated script against the edited blueprint/resolver logic).
- [x] Parsed the full `test/_config/step1` tree with all default parsers — zero errors, and the new fixture's `depends_on` resolves to the exact identifier string of its dependency.
- [x] Added `fn012_fn1()` / `fn012_fn2()` fixtures (`test/_config/step1/db1/sc1/function/`) and `test/function/fn012.py`, following the existing `fn00N` convention, for the live-Snowflake integration suite.
- [ ] Did not run `test/run_test_lite.sh` / `run_test_full.sh` — no Snowflake test-account credentials available in this environment. Would appreciate a maintainer/CI run to confirm `fn012` passes end-to-end.
